### PR TITLE
v0.7.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name='sosw',
-      version='0.7.11',
+      version='0.7.13',
       description='Serverless Orchestrator of Serverless Workers',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -44,16 +44,13 @@ class Processor:
 
         self.test = kwargs.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False
 
-        if self.test and not custom_config:
-            raise RuntimeError("You must specify a custom config from your testcase to run processor in test mode.")
-
         self.lambda_context = kwargs.pop('context', None)
         if self.lambda_context:
             self.aws_account = trim_arn_to_account(self.lambda_context.invoked_function_arn)
 
-        self.config = self.DEFAULT_CONFIG
+        self.config = self.DEFAULT_CONFIG or {}
         self.config = recursive_update(self.config,
-                                       self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config"))
+                                       self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config") or {})
         self.config = recursive_update(self.config, custom_config or {})
         logger.info(f"Final {self.__class__.__name__} processor config: {self.config}")
 

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -19,7 +19,6 @@ __license__ = "MIT"
 __status__ = "Production"
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 class Processor:
@@ -372,6 +371,9 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
         :param object context:  Lambda function context.
         :return: Result of the lambda function call.
         """
+
+        if event.get('logging_level'):
+            logger.setLevel(event.get('logging_level'))
 
         logger.info(f"Called {os.environ.get('AWS_LAMBDA_FUNCTION_NAME')} lambda of "
                     f"version {os.environ.get('AWS_LAMBDA_FUNCTION_VERSION')} with __name__: {__name__},"

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -111,23 +111,24 @@ class Processor:
             for suffix in client_suffixes:
                 try:
                     some_class = getattr(some_module, f"{service}{suffix}")
-                    some_client_config = self.config.get(f"{module_name}_config")
-                    logger.debug(f"Found config for {module_name}: {some_client_config}")
+                except AttributeError as e:
+                    logger.info(f"Didn't find {service} with suffix {suffix} in module {module_name}")
+                    continue
 
-                    # Send configs one of the two ways as `config` or `custom_config` for some backwards compatibility
-                    if some_client_config:
-                        if suffix == 'Manager':
-                            setattr(self, f"{module_name}_client", some_class(custom_config=some_client_config))
-                        elif suffix == 'Client':
-                            setattr(self, f"{module_name}_client", some_class(config=some_client_config))
+                some_client_config = self.config.get(f"{module_name}_config")
+                logger.debug(f"Found config for {module_name}: {some_client_config}")
 
-                    else:
-                        setattr(self, f"{module_name}_client", some_class())
-                    logger.info(f"Successfully registered {module_name}_client")
-                    break
-                except AttributeError:
-                    logger.info(f"Failed suffix {suffix}")
-                    pass
+                # Send configs one of the two ways as `config` or `custom_config` for some backwards compatibility
+                if some_client_config:
+                    if suffix == 'Manager':
+                        setattr(self, f"{module_name}_client", some_class(custom_config=some_client_config))
+                    elif suffix == 'Client':
+                        setattr(self, f"{module_name}_client", some_class(config=some_client_config))
+
+                else:
+                    setattr(self, f"{module_name}_client", some_class())
+                logger.info(f"Successfully registered {module_name}_client")
+                break
             else:
                 raise RuntimeError(f"Failed to import {service} from {some_module}. "
                                    f"Tried suffixes for class: {client_suffixes}")

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -97,7 +97,7 @@ class Processor:
                     some_module = import_module(path(module_name))
                     logger.debug(f"Imported {service} from {path(module_name)}")
                     break
-                except:
+                except Exception:
                     pass
 
             else:
@@ -105,7 +105,7 @@ class Processor:
                 try:
                     setattr(self, f"{module_name}_client", boto3.client(module_name))
                     continue
-                except:
+                except Exception:
                     raise RuntimeError(f"Failed to import for service {module_name}. Component naming problem.")
 
             for suffix in client_suffixes:
@@ -215,7 +215,7 @@ class Processor:
                 try:
                     self.stats.update(getattr(self, some_client).get_stats())
                     logger.info(f"Updated Processor stats with stats of {some_client}")
-                except:
+                except Exception:
                     logger.debug(f"{some_client} doesn't have get_stats() implemented. Recommended to fix this.")
 
         return self.stats
@@ -259,7 +259,7 @@ class Processor:
             for some_client in [x for x in dir(self) if x.endswith('_client')]:
                 try:
                     getattr(self, some_client).reset_stats()
-                except:
+                except Exception:
                     pass
 
 
@@ -267,7 +267,10 @@ class Processor:
         """
         Logs current Processor stats and `message`. Then raises RuntimeError with `message`.
 
-        :param str message:
+        If there is access to publish SNS messages, the method will also try to publish to the topic configured as
+        `dead_sns_topic` or `'SoswWorkerErrors'`.
+
+        :param str message: Description of failure.
         """
 
         logger.exception(message)
@@ -276,7 +279,17 @@ class Processor:
         result.update(self.get_stats())
         logger.info(result)
 
-        raise RuntimeError(message)
+        try:
+            sns_recipient = self.config.get('dead_sns_topic', 'SoswWorkerErrors')
+            sns_topic_arn = f'arn:aws:sns:{self._region}:{self._account}:{sns_recipient}'
+            sns_subject = f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'Some Function')} died"
+
+            sns = boto3.client('sns')
+            sns.publish(TopicArn=sns_topic_arn, Subject=sns_subject, Message=message)
+        except Exception:
+            logger.exception("Failed to send SNS message to Alarms.")
+
+        raise SystemExit(1)
 
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -292,12 +305,12 @@ class Processor:
 
         try:
             self.sql.sqldb.session.remove()
-        except:
+        except Exception:
             pass
 
         try:
             self.conn.close()
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/components/config.py
+++ b/sosw/components/config.py
@@ -61,7 +61,7 @@ class SSMConfig:
                     Names=[name],
                     WithDecryption=True
             )
-        except:
+        except Exception:
             response = ssm_client.get_parameters(
                     Names=[name],
                     WithDecryption=False
@@ -233,7 +233,7 @@ class DynamoConfig:
 
         try:
             return json.loads(config_value)
-        except:
+        except Exception:
             return config_value if config_value is not None else {}
 
 
@@ -269,7 +269,7 @@ class DynamoConfig:
         for row in items:
             try:
                 row['config_value'] = json.loads(row['config_value'])
-            except:
+            except Exception:
                 pass
             config_name = row['config_name'].replace(prefix, '')
             res[config_name] = row['config_value']

--- a/sosw/components/decorators.py
+++ b/sosw/components/decorators.py
@@ -40,7 +40,7 @@ def logging_wrapper(level: int = None):
                     s_parts.append(f"{k}={v},")
 
                 logging.log(level, " ".join(s_parts).strip(','))
-            except:
+            except Exception:
                 logging.log(level, f"Running {method.__name__} with args={args}, kwargs={kwargs}")
 
             result = method(*args, **kwargs)

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
 from .benchmark import benchmark
-from .helpers import chunks
+from .helpers import chunks, to_bool
 
 
 logger = logging.getLogger()
@@ -222,7 +222,9 @@ class DynamoDbClient:
                 val_dict = dynamo_row.get(key)  # Ex: {'N': "1234"} or {'S': "myvalue"}
                 if val_dict:
                     val = val_dict.get(key_type)  # Ex: 1234 or "myvalue"
-                    if key_type == 'N':
+                    if key_type == 'BOOL':
+                        result[key] = val
+                    elif key_type == 'N':
                         result[key] = float(val) if '.' in val else int(val)
                     elif key_type == 'S':
                         # Try to load to a dictionary if looks like JSON.
@@ -241,7 +243,9 @@ class DynamoDbClient:
         else:
             for key, key_type_and_val in dynamo_row.items():  # {'key1': {'Type1': 'val2'}, 'key2': {'Type2': 'val2'}}
                 for key_type, val in key_type_and_val.items():  # Ex: {'N': "1234"} or {'S': "myvalue"}
-                    if key_type == 'N':
+                    if key_type == 'BOOL':
+                        result[key] = val
+                    elif key_type == 'N':
                         result[key] = float(val) if '.' in val else int(val)
                     elif key_type == 'S':
                         # Try to load to a dictionary if looks like JSON.
@@ -282,9 +286,11 @@ class DynamoDbClient:
         if add_prefix is None:
             add_prefix = ''
 
-        result = {f"{add_prefix}{key}": {key_type: str(row_dict.get(key))} for (key, key_type) in
-                  self.row_mapper.items()
-                  if row_dict.get(key) is not None}
+        result = {}
+        for key, key_type in self.row_mapper.items():
+            if row_dict.get(key) is not None:
+                val = to_bool(row_dict[key]) if key_type == 'BOOL' else str(row_dict[key])
+                result[f"{add_prefix}{key}"] = {key_type: val}
         result_keys = result.keys()
         if add_prefix:
             result_keys = [x[len(add_prefix):] for x in result.keys()]
@@ -292,7 +298,9 @@ class DynamoDbClient:
             if not strict:
                 val = row_dict.get(key)
                 key_with_prefix = f"{add_prefix}{key}"
-                if isinstance(val, (int, float)) or (isinstance(val, str) and val.isnumeric()):
+                if isinstance(val, bool):
+                    result[key_with_prefix] = {'BOOL': to_bool(row_dict.get(key))}
+                elif isinstance(val, (int, float)) or (isinstance(val, str) and val.isnumeric()):
                     result[key_with_prefix] = {'N': str(row_dict.get(key))}
                 else:
                     result[key_with_prefix] = {'S': str(row_dict.get(key))}
@@ -639,7 +647,6 @@ class DynamoDbClient:
         return query
 
 
-    # @benchmark
     def put(self, row, table_name=None, overwrite_existing=True):
         """
         Adds a row to the database

--- a/sosw/components/helpers.py
+++ b/sosw/components/helpers.py
@@ -29,6 +29,7 @@ __all__ = ['validate_account_to_dashed',
            'trim_arn_to_name',
            'trim_arn_to_account',
            'make_hash',
+           'to_bool'
            ]
 
 import re
@@ -760,3 +761,14 @@ def make_hash(o):
         new_o[make_hash(k)] = make_hash(v)
 
     return hash(tuple(frozenset(sorted(new_o.items()))))
+
+
+def to_bool(val):
+    if isinstance(val, (bool, int, float)):
+        return bool(val)
+    elif isinstance(val, str):
+        if val.lower() in ['true', '1']:
+            return True
+        elif val.lower() in ['false', '0']:
+            return False
+    raise Exception(f"Can't convert unexpected value to bool: {val}, type: {type(val)}")

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -3,7 +3,6 @@ import logging
 import time
 import unittest
 import os
-from collections import defaultdict
 
 
 logging.getLogger('botocore').setLevel(logging.WARNING)
@@ -12,6 +11,7 @@ os.environ["STAGE"] = "test"
 os.environ["autotest"] = "True"
 
 from sosw.components.dynamo_db import DynamoDbClient, clean_dynamo_table
+from sosw.components.helpers import chunks
 
 
 class dynamodb_client_IntegrationTestCase(unittest.TestCase):
@@ -371,7 +371,7 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
         # Filter expression neggs the first three rows because they don't have `mark = 1`.
         keys = {self.HASH_COL: 'cat', self.RANGE_COL: 4}
         result = self.dynamo_client.get_by_query(keys=keys, comparisons={self.RANGE_COL: '<='},
-                                                 strict=False, filter_expression='mark = 1')
+                                                 fetch_all_fields=True, filter_expression='mark = 1')
         # print(result)
 
         self.assertEqual(len(result), 2)
@@ -380,7 +380,7 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
 
         # In the same test we check also some comparator _functions_.
         result = self.dynamo_client.get_by_query(keys=keys, comparisons={self.RANGE_COL: '<='},
-                                                 strict=False, filter_expression='attribute_exists mark')
+                                                 fetch_all_fields=True, filter_expression='attribute_exists mark')
         # print(result)
         self.assertEqual(len(result), 2)
         self.assertEqual([x[self.RANGE_COL] for x in result], list(range(3, 5)))
@@ -389,7 +389,7 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
         self.assertEqual(result[1], {self.HASH_COL: 'cat', self.RANGE_COL: 4, 'mark': 1})
 
         result = self.dynamo_client.get_by_query(keys=keys, comparisons={self.RANGE_COL: '<='},
-                                                 strict=False, filter_expression='attribute_not_exists mark')
+                                                 fetch_all_fields=True, filter_expression='attribute_not_exists mark')
         # print(result)
         self.assertEqual(len(result), 3)
         self.assertEqual([x[self.RANGE_COL] for x in result], list(range(3)))
@@ -590,6 +590,29 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
             }
         }
         self.assertDictEqual(expected, indexes)
+
+
+    def test_batch_get_items_one_table(self):
+        # If you want to stress test batch_get_items_one_table, use bigger numbers
+        num_of_items = 5
+        query_from = 2
+        query_till = 4
+        expected_items = query_till - query_from
+
+        # Write items
+        operations = []
+        query_keys = []
+        for i in range(num_of_items):
+            item = {self.HASH_COL: f'cat{i%2}', self.RANGE_COL: i}
+            operations.append({'Put': self.dynamo_client.build_put_query(item)})
+            query_keys.append(item)
+        for operations_chunk in chunks(operations, 10):
+            self.dynamo_client.dynamo_client.transact_write_items(TransactItems=operations_chunk)
+            time.sleep(1)  # cause the table has 10 write/sec capacity
+
+        # Batch get items
+        results = self.dynamo_client.batch_get_items_one_table(keys_list=query_keys[query_from:query_till])
+        self.assertEqual(expected_items, len(results))
 
 
 if __name__ == '__main__':

--- a/sosw/components/test/integration/test_dynamo_db_i.py
+++ b/sosw/components/test/integration/test_dynamo_db_i.py
@@ -26,7 +26,8 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
             'other_col':     'S',
             'new_col':       'S',
             'some_col':      'S',
-            'some_counter':  'N'
+            'some_counter':  'N',
+            'some_bool':     'BOOL',
         },
         'required_fields': ['lambda_name'],
         'table_name':      'autotest_dynamo_db',
@@ -57,7 +58,7 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
 
 
     def test_put(self):
-        row = {self.HASH_COL: 'cat', self.RANGE_COL: '123'}
+        row = {self.HASH_COL: 'cat', self.RANGE_COL: '123', 'some_bool': True}
 
         client = boto3.client('dynamodb')
 
@@ -79,7 +80,12 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
 
         items = result['Items']
 
-        self.assertTrue(len(items) > 0)
+        self.assertEqual(1, len(items))
+
+        expected = [{'hash_col':  {'S': 'cat'},
+                     'range_col': {'N': '123'},
+                     'some_bool': {'BOOL': True}}]
+        self.assertEqual(expected, items)
 
 
     def test_put__create(self):
@@ -265,7 +271,7 @@ class dynamodb_client_IntegrationTestCase(unittest.TestCase):
 
     def test_get_by_query__primary_index(self):
         keys = {self.HASH_COL: 'cat', self.RANGE_COL: '123'}
-        row = {self.HASH_COL: 'cat', self.RANGE_COL: 123, 'some_col': 'test'}
+        row = {self.HASH_COL: 'cat', self.RANGE_COL: 123, 'some_col': 'test', 'some_bool': True}
         self.dynamo_client.put(row, self.table_name)
 
         result = self.dynamo_client.get_by_query(keys=keys)

--- a/sosw/components/test/unit/test_dynamo_db.py
+++ b/sosw/components/test/unit/test_dynamo_db.py
@@ -27,7 +27,9 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
             'other_col':     'S',
             'new_col':       'S',
             'some_col':      'S',
-            'some_counter':  'N'
+            'some_counter':  'N',
+            'some_bool':     'BOOL',
+            'some_bool2':    'BOOL',
         },
         'required_fields': ['lambda_name'],
         'table_name':      'autotest_dynamo_db'
@@ -56,17 +58,21 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
 
 
     def test_dict_to_dynamo_strict(self):
-        dict_row = {'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456}
+        dict_row = {'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456, 'some_bool': True,
+                    'some_bool2': 'True'}
         dynamo_row = self.dynamo_client.dict_to_dynamo(dict_row)
-        expected = {'lambda_name': {'S': 'test_name'}, 'invocation_id': {'S': 'test_id'}, 'en_time': {'N': '123456'}}
+        expected = {
+            'lambda_name': {'S': 'test_name'}, 'invocation_id': {'S': 'test_id'}, 'en_time': {'N': '123456'},
+            'some_bool': {'BOOL': True}, 'some_bool2': {'BOOL': True}
+        }
         for key in expected.keys():
             self.assertDictEqual(expected[key], dynamo_row[key])
 
 
     def test_dict_to_dynamo_not_strict(self):
-        dict_row = {'name': 'cat', 'age': 3}
+        dict_row = {'name': 'cat', 'age': 3, 'other_bool': False, 'other_bool2': 'False'}
         dynamo_row = self.dynamo_client.dict_to_dynamo(dict_row, strict=False)
-        expected = {'name': {'S': 'cat'}, 'age': {'N': '3'}}
+        expected = {'name': {'S': 'cat'}, 'age': {'N': '3'}, 'other_bool': {'BOOL': False}}
         for key in expected.keys():
             self.assertDictEqual(expected[key], dynamo_row[key])
 
@@ -82,22 +88,22 @@ class dynamodb_client_UnitTestCase(unittest.TestCase):
     def test_dynamo_to_dict(self):
         dynamo_row = {
             'lambda_name': {'S': 'test_name'}, 'invocation_id': {'S': 'test_id'}, 'en_time': {'N': '123456'},
-            'extra_key':   {'N': '42'}
+            'extra_key':   {'N': '42'}, 'some_bool': {'BOOL': False}
         }
         dict_row = self.dynamo_client.dynamo_to_dict(dynamo_row)
-        expected = {'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456}
+        expected = {'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456, 'some_bool': False}
         self.assertDictEqual(dict_row, expected)
 
 
     def test_dynamo_to_dict_no_strict_row_mapper(self):
         dynamo_row = {
             'lambda_name': {'S': 'test_name'}, 'invocation_id': {'S': 'test_id'}, 'en_time': {'N': '123456'},
-            'extra_key_n': {'N': '42'}, 'extra_key_s': {'S': 'wowie'}
+            'extra_key_n': {'N': '42'}, 'extra_key_s': {'S': 'wowie'}, 'other_bool': {'BOOL': True}
         }
         dict_row = self.dynamo_client.dynamo_to_dict(dynamo_row, strict=False)
         expected = {
             'lambda_name': 'test_name', 'invocation_id': 'test_id', 'en_time': 123456, 'extra_key_n': 42,
-            'extra_key_s': 'wowie'
+            'extra_key_s': 'wowie', 'other_bool': True
         }
         self.assertDictEqual(dict_row, expected)
 

--- a/sosw/components/test/unit/test_helpers.py
+++ b/sosw/components/test/unit/test_helpers.py
@@ -604,5 +604,27 @@ class helpers_UnitTestCase(unittest.TestCase):
             self.assertEqual(make_hash(test[0]) == make_hash(test[1]), expected, f"Failed specific test: {test}")
 
 
+    def test_to_bool(self):
+        self.assertEqual(True, to_bool(1))
+        self.assertEqual(True, to_bool(1.0))
+        self.assertEqual(True, to_bool('1'))
+        self.assertEqual(True, to_bool('True'))
+        self.assertEqual(True, to_bool('true'))
+        self.assertEqual(False, to_bool(0))
+        self.assertEqual(False, to_bool(0.0))
+        self.assertEqual(False, to_bool('0'))
+        self.assertEqual(False, to_bool('false'))
+        self.assertEqual(False, to_bool('False'))
+
+        self.assertEqual(True, to_bool(5))
+        self.assertEqual(True, to_bool(0.001))
+
+        with self.assertRaises(Exception):
+            to_bool('unexpected')
+
+        with self.assertRaises(Exception):
+            to_bool(object())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sosw/managers/task.py
+++ b/sosw/managers/task.py
@@ -292,7 +292,7 @@ class TaskManager(Processor):
 
         try:
             new_task['payload'] = self.construct_payload_for_task(**kw)
-        except:
+        except Exception:
             raise ValueError(f"Unexpected `payload` or custom attrs for task '{kwargs}'. Should be dict() or JSON.")
 
         # Saving to DynamoDB.
@@ -314,7 +314,7 @@ class TaskManager(Processor):
         if isinstance(payload, str):
             try:
                 result = json.loads(payload)
-            except:
+            except Exception:
                 result = dict(payload=payload)
         elif not isinstance(payload, dict):
             result = dict(payload=payload)

--- a/sosw/managers/task.py
+++ b/sosw/managers/task.py
@@ -486,7 +486,7 @@ class TaskManager(Processor):
                 },
                 table_name=self.config['dynamo_db_config']['table_name'],
                 index_name=self.config['dynamo_db_config']['index_greenfield'],
-                strict=True,
+                fetch_all_fields=False,
                 max_items=cnt,
                 comparisons={
                     self.get_db_field_name('greenfield'): '<'

--- a/sosw/managers/test/integration/test_task_i.py
+++ b/sosw/managers/test/integration/test_task_i.py
@@ -214,7 +214,7 @@ class TaskManager_IntegrationTestCase(unittest.TestCase):
             mock_time.return_value = self.NOW_TIME
             self.manager.mark_task_invoked(self.LABOURER, row)
 
-        result = self.dynamo_client.get_by_query({self.HASH_KEY[0]: f"task_id_{self.LABOURER.id}_256"}, strict=False)
+        result = self.dynamo_client.get_by_query({self.HASH_KEY[0]: f"task_id_{self.LABOURER.id}_256"}, fetch_all_fields=True)
         # print(f"The new updated value of task is: {result}")
 
         # Rounded -2 we check that the greenfield was updated

--- a/sosw/managers/test/unit/test_task.py
+++ b/sosw/managers/test/unit/test_task.py
@@ -7,7 +7,6 @@ import time
 import unittest
 import uuid
 
-from collections import defaultdict
 from copy import deepcopy
 from unittest.mock import Mock, MagicMock, patch
 
@@ -17,9 +16,11 @@ logging.getLogger('botocore').setLevel(logging.WARNING)
 os.environ["STAGE"] = "test"
 os.environ["autotest"] = "True"
 
+from sosw.components import dynamo_db
 from sosw.labourer import Labourer
 from sosw.managers.task import TaskManager
 from sosw.test.variables import TEST_TASK_CLIENT_CONFIG
+from sosw.test.helpers_test import extract_call_params
 
 
 class task_manager_UnitTestCase(unittest.TestCase):
@@ -48,7 +49,7 @@ class task_manager_UnitTestCase(unittest.TestCase):
         with patch('boto3.client'):
             self.manager = TaskManager(custom_config=self.config)
 
-        self.manager.dynamo_db_client = MagicMock()
+        self.manager.dynamo_db_client = MagicMock(spec=dynamo_db.DynamoDbClient)
         self.manager.ecology_client = MagicMock()
         self.manager.ecology_client.get_labourer_status.return_value = 2
         self.manager.lambda_client = MagicMock()
@@ -279,46 +280,45 @@ class task_manager_UnitTestCase(unittest.TestCase):
         self.manager.dynamo_db_client.delete.assert_called_once_with({'task_id': task_id})
 
 
-    # @unittest.skip("Function currently depricated")
-    # def test_close_task(self):
-    #     _ = self.manager.get_db_field_name
-    #     task_id = '918273'
-    #     labourer_id = 'some_lambda'
-    #
-    #     # Mock
-    #     self.manager.dynamo_db_client = MagicMock()
-    #
-    #     # Call
-    #     self.manager.close_task(task_id, 'some_lambda')
-    #
-    #     # Check calls
-    #     self.manager.dynamo_db_client.update.assert_called_once_with(
-    #             {_('task_id'): task_id, _('labourer_id'): labourer_id},
-    #             attributes_to_update={_('closed_at'): int(time.time())})
+    def test__jsonify_payload_of_task(self):
+        TESTS = [
+            ({'foo': 'some_lambda', 'payload': '{"bar": 42}'}, {'foo': 'some_lambda', 'payload': '{"bar": 42}'}),
+            ({'foo': 'some_lambda', 'payload': {'bar': 42}}, {'foo': 'some_lambda', 'payload': '{"bar": 42}'}),
+            ({'foo': {'a': 1}}, {'foo': {'a': 1}}),
+        ]
 
-    def move_task_to_retry_table(self):
+        for test, expected in TESTS:
+            self.assertEqual(self.manager._jsonify_payload_of_task(test), expected)
+
+
+    def test_move_task_to_retry_table(self):
         task_id = '123'
-        task = {'labourer_id': 'some_lambda', 'task_id': task_id, 'payload': '{}'}
+        TEST = {'labourer_id': 'some_lambda', 'task_id': task_id, 'payload': '{"bar": 42}'}
         delay = 350
 
-        # Mock
-        self.manager.dynamo_db_client = MagicMock()
 
-        self.manager.move_task_to_retry_table(task, delay)
+        with patch('time.time') as t:
+            t.return_value = 1000
+            self.manager.move_task_to_retry_table(TEST, delay)
 
-        retry_task = {'labourer_id': 'some_lambda', 'task_id': task_id, 'payload': '{}'}
-        called_with_row = self.manager.dynamo_db_client.put.call_args[0][0]
-        called_with_table = self.manager.dynamo_db_client.put.call_args[0][2]
+        params = extract_call_params(self.manager.dynamo_db_client.put.call_args, dynamo_db.DynamoDbClient.put)
+        # print(params)
 
-        for k in retry_task:
-            self.assertEqual(retry_task[k], called_with_row[k])
-        for k in called_with_row:
-            if k != 'desired_launch_time':
-                self.assertEqual(retry_task[k], called_with_row[k])
+        desired_time = params['row'].pop('desired_launch_time')
+        self.assertEqual(desired_time, 1000 + delay, "Delay was not added to the current time.")
 
-        self.assertTrue(time.time() - 60 < called_with_row['desired_launch_time'] < time.time() + 60)
+        self.assertDictEqual(TEST, params['row'], "Task for retry table doesn't match original.")
+        self.assertEqual(params['table_name'], self.config['sosw_retry_tasks_table'], "Retry writes to invalid table.")
 
-        self.assertEqual(called_with_table, self.config['sosw_retry_tasks_table'])
+
+    def test_move_task_to_retry_table__dumps_payload(self):
+        TEST = {'labourer_id': 'foo', 'task_id': 123, 'payload': {'bar': 42}}
+
+        self.manager.move_task_to_retry_table(TEST, 1)
+
+        params = extract_call_params(self.manager.dynamo_db_client.put.call_args, dynamo_db.DynamoDbClient.put)
+
+        self.assertEqual(json.dumps(TEST['payload']), params['row']['payload'], "Payload was JSON-nified")
 
 
     def test_get_tasks_to_retry_for_labourer(self):

--- a/sosw/scavenger.py
+++ b/sosw/scavenger.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 from sosw.app import Processor
 from sosw.labourer import Labourer
-
+from sosw.managers.task import TaskManager
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -29,7 +29,7 @@ class Scavenger(Processor):
     }
 
     # these clients will be initialized by Processor constructor
-    task_client = None
+    task_client: TaskManager = None
     sns_client = None
 
 

--- a/sosw/test/helpers_test.py
+++ b/sosw/test/helpers_test.py
@@ -7,7 +7,7 @@ def line_count(file):
     try:
         # This is the FAST way
         return int(subprocess.check_output(f'wc -l {file}', shell=True).split()[0])
-    except:
+    except Exception:
         # This is in case you are running in some creepy environment without shell access
         i = 0
         with open(file, 'r') as f:

--- a/sosw/test/helpers_test.py
+++ b/sosw/test/helpers_test.py
@@ -1,6 +1,44 @@
-__all__ = ['line_count']
+__all__ = ['extract_call_params', 'line_count']
 
+import inspect
 import subprocess
+
+from typing import Dict
+
+
+def extract_call_params(call_args, function) -> Dict:
+    """
+    Combines a dictionary out of Mock.call_args.
+    Helper useful to validate specific call parameters of the Mocked function.
+
+    When you are not sure if your function is called with args or kwargs, you just feed the call_args
+    and the source of function to this helper and receive a dictionary.
+
+    .. _code-block:: python
+
+       call_kwargs = extract_call_params(your_mock_object.some_method.call_args, mocked_module.Class.method)
+
+    :param call_args:   call_args of Mock object
+    :param function:    Source object that was initially mocked
+    :rtype:             dict
+    """
+
+    # Specification of arguments of function
+    function_args = inspect.getfullargspec(function).args
+
+    # Mock call_arguments as a tuple
+    call_args, call_kwargs = call_args
+
+    result = {}
+
+    for i, v in enumerate(call_args):
+        position = i + 1 if function_args[0] == 'self' else i
+        result[function_args[position]] = v
+
+    for k, v in call_kwargs.items():
+        result[k] = v
+
+    return result
 
 
 def line_count(file):

--- a/sosw/test/integration/test_orchestrator_i.py
+++ b/sosw/test/integration/test_orchestrator_i.py
@@ -36,7 +36,7 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/test/integration/test_scheduler_i.py
+++ b/sosw/test/integration/test_scheduler_i.py
@@ -52,7 +52,7 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
         if only_remote:
             try:
                 os.remove(local or self.scheduler.local_queue_file)
-            except:
+            except Exception:
                 pass
 
 
@@ -84,12 +84,12 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
 
         try:
             os.remove(self.scheduler.local_queue_file)
-        except:
+        except Exception:
             pass
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/test/unit/test_app.py
+++ b/sosw/test/unit/test_app.py
@@ -35,10 +35,11 @@ class app_UnitTestCase(unittest.TestCase):
         self.assertTrue(True)
 
 
-    @mock.patch("boto3.client")
-    def test_app_init__fails_without_custom_config(self, mock_boto_client):
-        self.assertRaises(RuntimeError, Processor)
-
+    # Behaviour is deprecated.
+    # @mock.patch("boto3.client")
+    # def test_app_init__fails_without_custom_config(self, mock_boto_client):
+    #     self.assertRaises(RuntimeError, Processor)
+    #
 
     @mock.patch("boto3.client")
     def test_app_init__with_some_clients(self, mock_boto_client):

--- a/sosw/test/unit/test_app.py
+++ b/sosw/test/unit/test_app.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from sosw.app import Processor, LambdaGlobals, get_lambda_handler
 from sosw.components.sns import SnsManager
@@ -25,7 +25,7 @@ class app_UnitTestCase(unittest.TestCase):
     def tearDown(self):
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 
@@ -123,3 +123,46 @@ class app_UnitTestCase(unittest.TestCase):
             self.assertEqual(result, 'success')
             self.assertEqual(global_vars.processor.stats['total_processor_calls'], i + 1)
             self.assertEqual(global_vars.processor.stats['total_calls_register_clients'], 1)
+
+
+    @mock.patch("boto3.client")
+    def test_die(self, mock_boto):
+
+        p = Processor(custom_config=self.TEST_CONFIG)
+
+        with self.assertRaises(SystemExit):
+            p.die()
+
+
+    @mock.patch("boto3.client")
+    def test_die__uncatchable_death(self, mock_boto):
+
+        class Child(Processor):
+            def catch_me(self):
+                try:
+                    self.die()
+                except Exception:
+                    pass
+
+        p = Child(custom_config=self.TEST_CONFIG)
+
+        with self.assertRaises(SystemExit):
+            p.catch_me()
+
+
+    @mock.patch("boto3.client")
+    def test_die__calls_sns(self, mock_boto):
+
+        mock_boto_client = MagicMock()
+        mock_boto.return_value = mock_boto_client
+
+        p = Processor(custom_config=self.TEST_CONFIG)
+
+        with self.assertRaises(SystemExit):
+            p.die()
+
+        mock_boto_client.publish.assert_called_once()
+        args, kwargs = mock_boto_client.publish.call_args
+        self.assertIn('SoswWorkerErrors', kwargs['TopicArn'])
+        self.assertEqual(kwargs['Subject'], 'Some Function died')
+        self.assertEqual(kwargs['Message'], 'Unknown Failure')

--- a/sosw/test/unit/test_orchestrator.py
+++ b/sosw/test/unit/test_orchestrator.py
@@ -35,7 +35,7 @@ class Orchestrator_UnitTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/test/unit/test_scavenger.py
+++ b/sosw/test/unit/test_scavenger.py
@@ -45,7 +45,7 @@ class Scavenger_UnitTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/test/unit/test_scheduler.py
+++ b/sosw/test/unit/test_scheduler.py
@@ -100,13 +100,13 @@ class Scheduler_UnitTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
         for fname in [self.scheduler.local_queue_file, self.FNAME]:
             try:
                 os.remove(fname)
-            except:
+            except Exception:
                 pass
 
 
@@ -318,7 +318,7 @@ class Scheduler_UnitTestCase(unittest.TestCase):
                 pattern = '[a-z]+_([0-9]+)_days'
                 try:
                     expected_number = int(re.match(pattern, test['period'])[1])
-                except:
+                except Exception:
                     expected_number = 1
             else:
                 expected_number = 1
@@ -496,7 +496,7 @@ class Scheduler_UnitTestCase(unittest.TestCase):
         def find_product(t):
             try:
                 return set(t['product_versions'].keys()) == {'product_version_audio', 'product_version_paper'}
-            except:
+            except Exception:
                 return False
 
 

--- a/sosw/test/unit/test_worker.py
+++ b/sosw/test/unit/test_worker.py
@@ -24,7 +24,7 @@ class worker_UnitTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/test/unit/test_worker_assistant.py
+++ b/sosw/test/unit/test_worker_assistant.py
@@ -26,7 +26,7 @@ class WorkerAssistantUnitTestCase(unittest.TestCase):
 
         try:
             del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
-        except:
+        except Exception:
             pass
 
 

--- a/sosw/worker.py
+++ b/sosw/worker.py
@@ -44,7 +44,7 @@ class Worker(Processor):
         # Mark the task as completed in DynamoDB if the event had task_id.
         try:
             self.mark_task_as_completed(event.get('task_id'))
-        except:
+        except Exception:
             logger.exception(f"Failed to call WorkerAssistant for event {event}")
             pass
 


### PR DESCRIPTION
- dynamo_db: parameter `fetch_all_fields` for getter functions
- dynamo_db: critical `fix batch_get_items`
- dynamo_db: support `bool` fields in row_mapper
- Scavenger: critical fixes
- override logging level in handler event
- improved `die()` of Processor. Recommended to use when critical Exception
- test.helper: `extract_call_params`