### PR TITLE
Scheduler fix

### DIFF
--- a/sosw/app.py
+++ b/sosw/app.py
@@ -45,6 +45,7 @@ class Processor:
 
         self.lambda_context = kwargs.pop('context', None)
         if self.lambda_context:
+            logger.warning("DEPRECATED: Processor.lambda_context is deprecated. Use global_vars.lambda_context instead")
             self.aws_account = trim_arn_to_account(self.lambda_context.invoked_function_arn)
 
         self.config = self.DEFAULT_CONFIG or {}
@@ -398,3 +399,7 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
 
 
     return lambda_handler
+
+# Global placeholder for global_vars. This one is not really used and should exist in the root application
+# of your Lambda. See Worker examples in documentation for more info.
+global_vars = LambdaGlobals()

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -323,6 +323,22 @@ _lambda_context = None
 
 
 class LambdaGlobals:
+    """
+    Global placeholder for global_vars that we want to preserve in the lifetime of the Lambda Container.
+    e.g. once initiailised the given Processor, we keep it alive in the container to minimize warm-run time.
+
+    This namespace also contains the lambda_context which should be reset by `get_lambda_handler` method.
+    See Worker examples in documentation for more info.
+    """
+
+    def __init__(self):
+        """
+        Reset the lambda context for every reinitialization.
+        The Processor may stay alive in the scope of Lambda container, but the context is unique per invocation.
+        The Lambda Globals should also be reset by `get_lambda_handler` method.
+        """
+        global  _lambda_context
+        _lambda_context = None
 
     @property
     def lambda_context(self):
@@ -400,6 +416,5 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
 
     return lambda_handler
 
-# Global placeholder for global_vars. This one is not really used and should exist in the root application
-# of your Lambda. See Worker examples in documentation for more info.
+# Global placeholder for global_vars.
 global_vars = LambdaGlobals()

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -6,27 +6,20 @@ __version__ = "0.1"
 __license__ = "MIT"
 __status__ = "Development"
 
-import boto3
 import datetime
 import json
 import logging
-import math
 import os
 import re
 import time
 
-from importlib import import_module
-from collections import Counter
-from collections import defaultdict
-from collections import OrderedDict
 from collections import Iterable
 from copy import deepcopy
 from typing import List, Set, Tuple, Union, Optional, Dict
 
-from sosw.app import Processor
+from sosw.app import Processor, LambdaGlobals
 from sosw.components.helpers import get_list_of_multiple_or_one_or_empty_from_dict, trim_arn_to_name, chunks
 from sosw.components.siblings import SiblingsManager
-from sosw.labourer import Labourer
 from sosw.managers.task import TaskManager
 
 
@@ -115,6 +108,8 @@ class Scheduler(Processor):
             self.parse_job_to_file(job)
 
         self.process_file()
+
+        super().__call__(event)
 
 
     def parse_job_to_file(self, job: Dict):
@@ -570,11 +565,11 @@ class Scheduler(Processor):
                 # Spawning another sibling to continue the processing
                 try:
                     payload = dict(file_name=file_name)
-                    self.siblings_client.spawn_sibling(self.lambda_context, payload=payload)
+                    self.siblings_client.spawn_sibling(global_vars.lambda_context, payload=payload)
                     self.stats['siblings_spawned'] += 1
 
                 except Exception as err:
-                    logger.exception(f"Could not spawn sibling with context: {self.lambda_context}, payload: {payload}")
+                    logger.exception(f"Could not spawn sibling with context: {global_vars.lambda_context}, payload: {payload}")
 
             self.upload_and_unlock_queue_file()
             self.clean_tmp()
@@ -648,7 +643,7 @@ class Scheduler(Processor):
         Return if there is a sufficient execution time for processing ('shutdown period' is in seconds).
         """
 
-        return self.lambda_context.get_remaining_time_in_millis() > self.config['shutdown_period'] * 1000
+        return global_vars.lambda_context.get_remaining_time_in_millis() > self.config['shutdown_period'] * 1000
 
 
     def get_and_lock_queue_file(self) -> str:
@@ -716,7 +711,7 @@ class Scheduler(Processor):
         if name is None:
             filename_parts = self.config['queue_file'].rsplit('.', 1)
             assert len(filename_parts) == 2, "Got bad file name"
-            self._queue_file_name = f"{filename_parts[0]}_{self.lambda_context.aws_request_id}.{filename_parts[1]}"
+            self._queue_file_name = f"{filename_parts[0]}_{global_vars.lambda_context.aws_request_id}.{filename_parts[1]}"
         else:
             self._queue_file_name = name
 
@@ -739,3 +734,5 @@ class Scheduler(Processor):
         Concurrent processes should not touch it.
         """
         return f"{self.config['s3_prefix'].strip('/')}/locked_{self._queue_file_name}"
+
+global_vars = LambdaGlobals()

--- a/sosw/test/integration/test_scheduler_i.py
+++ b/sosw/test/integration/test_scheduler_i.py
@@ -6,7 +6,7 @@ import unittest
 
 from unittest.mock import MagicMock, patch
 
-from sosw.scheduler import Scheduler
+from sosw.scheduler import Scheduler, global_vars
 from sosw.labourer import Labourer
 from sosw.test.variables import TEST_SCHEDULER_CONFIG
 from sosw.test.helpers_test import line_count
@@ -68,12 +68,13 @@ class Scheduler_IntegrationTestCase(unittest.TestCase):
         self.get_config_patch = self.patcher.start()
 
         self.custom_config = self.TEST_CONFIG.copy()
-        self.lambda_context = types.SimpleNamespace()
-        self.lambda_context.aws_request_id = 'AWS_REQ_ID'
-        self.lambda_context.invoked_function_arn = 'arn:aws:lambda:us-west-2:000000000000:function:some_function'
-        self.lambda_context.get_remaining_time_in_millis = MagicMock(side_effect=[100000, 100])
+        lambda_context = types.SimpleNamespace()
+        lambda_context.aws_request_id = 'AWS_REQ_ID'
+        lambda_context.invoked_function_arn = 'arn:aws:lambda:us-west-2:000000000000:function:some_function'
+        lambda_context.get_remaining_time_in_millis = MagicMock(side_effect=[100000, 100])
+        global_vars.lambda_context = lambda_context
 
-        self.scheduler = Scheduler(self.custom_config, context=self.lambda_context)
+        self.scheduler = Scheduler(self.custom_config)
 
         self.s3_client = boto3.client('s3')
 

--- a/sosw/test/unit/test_app.py
+++ b/sosw/test/unit/test_app.py
@@ -5,13 +5,12 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+os.environ["STAGE"] = "test"
+os.environ["autotest"] = "True"
+
 from sosw.app import Processor, LambdaGlobals, get_lambda_handler, logger
 from sosw.components.sns import SnsManager
 from sosw.components.siblings import SiblingsManager
-
-
-os.environ["STAGE"] = "test"
-os.environ["autotest"] = "True"
 
 
 class app_UnitTestCase(unittest.TestCase):


### PR DESCRIPTION
- Scheduler uses global_vars
- Reset lambda_context during re-initialisation of LambdaGlobals