### PR TITLE
3.0.0: CI on GitHub Workflows + spec/steering (work stream 1)

### DIFF
--- a/.aws/config
+++ b/.aws/config
@@ -1,2 +1,0 @@
-[default]
-region = us-west-2

--- a/.github/workflows/docs-builder-action.yaml
+++ b/.github/workflows/docs-builder-action.yaml
@@ -1,9 +1,12 @@
-name: Docs Builder
+# Builds the Sphinx documentation on every pull request with warnings treated as errors (-W).
+# Verified locally against the current docs: the build passes -W with zero warnings.
+
+name: Docs
 
 on:
   pull_request:
     branches:
-      - "**"
+      - '**'
 
 jobs:
   build:
@@ -15,18 +18,12 @@ jobs:
     - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: '3.13'
 
-
-    - name: Install packages
-      run: sudo apt-get install python3-sphinx; pip install pipenv; pipenv install --dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
 
     - name: Build docs
-      run: pipenv run sphinx-build -Wab html ./docs ./sosw-rtd
-
-#    - name: Configure AWS secrets
-#      run: aws configure set aws_access_key_id ${{secrets.AWS_ACCESS_KEY_ID}}; aws configure set aws_secret_access_key ${{secrets.AWS_SECRET_ACCESS_KEY}}; aws configure set default.region us-west-2
-#
-#    - name: Synchronise sample docs
-#      run: VERSION=`cat setup.py | grep version | awk -F\' '{print $2}'`; cd sosw-rtd; aws s3 sync . s3://sosw-documentation-${{secrets.ACCOUNT_ID}}/junkyard/${{github.ref.name}} --acl public-read
-
+      run: python -m sphinx -W -a -b html docs sosw-rtd

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,12 +1,23 @@
-name: Publish release to PyPI and RCs to TestPyPI
+# Publishes a release candidate to TestPyPI on every push to a staging version branch.
+#
+# Fixes GitHub issue #267: the old `pull_request` trigger combined with
+# `if: startsWith(github.ref, 'refs/heads/0_')` never fired, because pull_request events
+# run on `refs/pull/<N>/merge`, so the publish steps were always skipped.
+
+name: Publish RC to TestPyPI
+
 on:
-  pull_request:
+  push:
+    # GitHub branch-filter glob semantics: '[0-9]' matches exactly one digit, '*' matches
+    # any characters except '/'. So '[0-9]*_*' matches staging version branches named per
+    # the X_Y_Z convention — e.g. 0_7_51, 3_0_0, 10_2_1 — and does not match master,
+    # docme or feature branches.
     branches:
-      - "master"
+      - '[0-9]*_*'
 
 jobs:
   build-n-publish:
-    name: Build and publish distribution
+    name: Build and publish RC distribution
     runs-on: ubuntu-latest
 
     steps:
@@ -15,22 +26,51 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: '3.13'
 
     - name: Install pypa/build
       run: python3 -m pip install build --user
 
-    - name: Patch the RC version number with the current timestamp. Need this to avoid duplication
-      if: startsWith(github.ref, 'refs/heads/0_')
-      run: >-
-        sed -i -E "s/version='([0-9].[0-9]+.[0-9]+)/version='\1_`date +%s`/" setup.py
+    # The trigger above already restricts this workflow to staging version branches, so the
+    # steps below run unconditionally: the old `startsWith(github.ref, 'refs/heads/0_')`
+    # guards are replaced by the branch filter itself.
+    - name: Patch the RC version with the current timestamp to avoid duplicates on TestPyPI
+      run: |
+        python3 - <<'EOF'
+        """Append rc<unix-ts> to the package version, PEP 440 style (e.g. 3.0.0rc1751581234).
+
+        Works both before and after the pyproject.toml migration: patches the version
+        string in pyproject.toml if it carries one, otherwise falls back to setup.py.
+        """
+        import re
+        import time
+
+        from pathlib import Path
+
+        SUFFIX = 'rc%d' % int(time.time())
+        PATTERNS = {
+            'pyproject.toml': r'(?m)^(version\s*=\s*[\'"])([^\'"]+)',
+            'setup.py':       r'(version\s*=\s*[\'"])([^\'"]+)',
+        }
+
+        for filename, pattern in PATTERNS.items():
+            path = Path(filename)
+            if not path.exists():
+                continue
+            patched, count = re.subn(pattern, r'\g<1>\g<2>' + SUFFIX, path.read_text(), count=1)
+            if count:
+                path.write_text(patched)
+                print('Patched %s with RC version suffix %s' % (filename, SUFFIX))
+                break
+        else:
+            raise SystemExit('No version string found in pyproject.toml or setup.py')
+        EOF
 
     - name: Build a binary wheel and a source tarball
       run: >-
         python3 -m build --sdist --wheel --outdir dist/ .
 
     - name: Publish distribution 📦 to Test PyPI
-      if: startsWith(github.ref, 'refs/heads/0_')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -8,12 +8,13 @@ name: Publish RC to TestPyPI
 
 on:
   push:
-    # GitHub branch-filter glob semantics: '[0-9]' matches exactly one digit, '*' matches
-    # any characters except '/'. So '[0-9]*_*' matches staging version branches named per
-    # the X_Y_Z convention — e.g. 0_7_51, 3_0_0, 10_2_1 — and does not match master,
-    # docme or feature branches.
+    # GitHub branch-filter glob semantics: '[0-9]' matches one digit, '+' matches one or
+    # more of the preceding character, and the pattern must match the whole branch name.
+    # So '[0-9]+_[0-9]+_[0-9]+' matches exactly the X_Y_Z staging convention — e.g.
+    # 0_7_51, 3_0_0, 10_2_1 — and does not match master, docme, feature branches, or
+    # loose names like 3_0_0_backup.
     branches:
-      - '[0-9]*_*'
+      - '[0-9]+_[0-9]+_[0-9]+'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -1,31 +1,54 @@
-# This workflow will install Python dependencies and run unit tests with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# Runs the sosw unit test suite on every pull request: once per supported Python version,
+# plus a separate coverage job that enforces the minimum line coverage threshold.
 
-name: Run Unittests
+name: Tests
 
 on:
   pull_request:
     branches:
-      - "**"
+      - '**'
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest boto3
-    - name: Test with pytest
+
+    - name: Run unit tests
+      run: python -m pytest sosw/test/suite_unit.py
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
       run: |
-        python -m pytest sosw/test/suite_unit.py
+        python -m pip install --upgrade pip
+        python -m pip install pytest pytest-cov boto3
+
+    # The 75% threshold is a staging value: the tests & coverage PR of the 3.0.0 release
+    # raises it to 100.
+    - name: Run unit tests with coverage
+      run: python -m pytest sosw/test/suite_unit.py --cov=sosw --cov-report=term --cov-fail-under=75

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # PyCharm
 .idea/
+
+# Claude Code (worktrees, local settings); .kiro/ stays tracked
+.claude/

--- a/.kiro/specs/hq-692-sosw-3-0-0/design.md
+++ b/.kiro/specs/hq-692-sosw-3-0-0/design.md
@@ -1,0 +1,107 @@
+# sosw 3.0.0 — Design
+
+## 1. Module disposition
+
+| Module | 3.0 status | Notes |
+|---|---|---|
+| `sosw/app.py` | CORE | `Processor`, `LambdaGlobals`, `get_lambda_handler`; gains shared handler builder + warm-start fixes |
+| `sosw/lambda_api.py` | NEW CORE | `LambdaApi(Processor)` declarative API Gateway base |
+| `sosw/durable.py` | NEW CORE | `get_durable_lambda_handler` + SDK-optional helpers |
+| `sosw/components/*` (config, dynamo_db, helpers, sns, siblings, sigv4, exceptions, decorators, benchmark) | COMPONENT | kept, tidied, 100% covered; `exceptions` gains `ApiError` hierarchy |
+| `sosw/orchestrator.py`, `scavenger.py`, `scheduler.py`, `worker.py`, `worker_assistant.py`, `labourer.py`, `essential.py`, `managers/task.py`, `managers/ecology.py`, `managers/meta_handler.py` | DEPRECATED | functional through 3.x, removed in 4.0 |
+
+## 2. Deprecation mechanics
+
+- One shared helper (`sosw/components/decorators.py` or a tiny `sosw/_deprecation.py`) emits
+  `DeprecationWarning` with a per-class once-guard; message template:
+  `"<Name> is deprecated since sosw 3.0.0 and will be removed in 4.0. sosw is now a Lambda bootstrapping framework; see the migration guide: <docs url>."`
+- Warning is emitted from `__init__` of each deprecated class (module import stays silent — module-level
+  warnings would fire on internal imports and on `from sosw import X` re-exports).
+- `sosw/__init__.py` becomes a **lazy façade** via module `__getattr__` (PEP 562): `import sosw` imports
+  nothing heavy; `sosw.Processor`, `sosw.LambdaApi` resolve lazily without warnings; `sosw.Orchestrator`
+  etc. resolve lazily (their `__init__` warns on instantiation).
+- `siblings.py` drops its `from sosw import Processor` package-level import in favor of
+  `from sosw.app import Processor` (avoids the façade round-trip).
+- The docs migration page maps every deprecated entity to its guidance (self-hosted orchestration →
+  Step Functions / EventBridge / durable functions).
+
+## 3. Warm start
+
+Behavior-preserving refactor of `get_lambda_handler` into a shared `_make_lambda_handler(...)`
+used by both the classic and durable handler factories. Fixes riding along:
+
+- `test` flag precedence: `kwargs.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False`
+  parses as `A or (B if C else D)`; rewritten to explicit logic honoring an explicitly passed flag.
+- Single `reset_stats()` per invocation (currently called twice, non-recursive then recursive).
+- `disable_ddb_config` config/class flag to skip per-function DDB/SSM config lookup (PR #376 absorbed).
+- Processor caching contract documented: one Processor per container via `LambdaGlobals`; per-invocation
+  state lives in `self.result` (reset each call), lifetime accumulators in `self.stats` (`total_*` preserved).
+
+## 4. lambda_api
+
+Top-level `sosw/lambda_api.py` (a peer of the handler factories, not a `components/` client).
+
+- **Router**: config `routes = {'GET /things': 'get_things', ...}` mapping to bound method names;
+  supports API Gateway REST (v1) and HTTP API (v2) event shapes; path parameters via APIGW resource syntax.
+- **Auth**: Cognito JWT claims already verified by the API Gateway authorizer; LambdaApi extracts claims
+  from both `requestContext.authorizer.claims` (v1) and `requestContext.authorizer.jwt.claims` (v2),
+  tolerates numeric/string `exp`, exposes `self.claims`; optional `authorized_groups` config gate and a
+  `check_route_access(route, claims)` hook for downstream RBAC.
+- **Responses**: `make_response(body, status_code=200, headers=None)` with config-driven CORS headers,
+  JSON encoder handling `Decimal`/`datetime`/`set` (DynamoDB-friendly), passthrough for pre-rendered
+  `{'statusCode': ...}` dicts.
+- **Errors**: `ApiError(Exception)` hierarchy in `sosw.components.exceptions` —
+  `BadRequestError(400)`, `UnauthorizedError(401)`, `ForbiddenError(403)`, `NotFoundError(404)`,
+  `ConflictError(409)`, `ServerError(500)`. `__call__` catches `ApiError` → envelope
+  `{'error': {'code', 'message'}}`; unexpected exceptions → logged with stack, generic 500 envelope.
+- **Stats**: per-route counters through `self.stats`.
+- Explicitly NOT ported from private forebears: SQLAlchemy session stack, org-specific permission
+  modules, hardcoded CORS origins, hardcoded Cognito group names.
+
+## 5. Durable functions
+
+- `sosw/durable.py`: `get_durable_lambda_handler(processor_class, global_vars=None, custom_config=None, **durable_kwargs)`
+  → wraps the shared handler with the durable-execution SDK decorator. Import of the SDK guarded;
+  missing SDK raises `ImportError("... pip install sosw[durable]")` at module import.
+- Helpers usable with or without the SDK: `durable_wait(seconds)` (SDK wait or `time.sleep` fallback),
+  `parse_durable_result(payload)` (unwraps `{"Status": ..., "Result": ...}` sync-invoke envelopes).
+- `sosw.app` keeps zero knowledge of the SDK.
+- Docs carry the operational constraints: determinism requirements, 256KB step payload limit, qualified
+  ARN invocation, and the step-after-variable-wait-loop hazard.
+- Packaging: `[project.optional-dependencies] durable = ["aws-durable-execution-sdk-python"]`.
+
+## 6. Tests & coverage
+
+- Suite stays `unittest`-style, registered explicitly in `sosw/test/suite_unit.py`; CI runs only that suite.
+- boto3 fully mocked (`patch('boto3.client')`, `patch.object(Processor, 'get_config')`); no moto, no network.
+- Optional-powertools import guards covered by reloading modules under a patched `sys.modules`
+  (both `ImportError` and success branches) — no `# pragma: no cover`.
+- Orphan test files (`test_essential`, unit `test_secrets_manager`, `test_dynamo_db_init`) registered;
+  duplicate legacy `components/test/test_config.py` retired in favor of the unit variant.
+- Coverage gate: `--cov=sosw --cov-fail-under=100` in CI (test dirs excluded via `.coveragerc`).
+
+## 7. CI/CD
+
+- `run-unittests.yml`: matrix 3.10/3.11/3.12/3.13/3.14 → pytest suite; separate `coverage` job (3.13)
+  with `--cov-fail-under`.
+- `docs-builder-action.yaml`: pip-based install (no pipenv), `sphinx-build -W`.
+- `publish-to-test-pypi.yml`: RC trigger pattern covers `[0-9]+_[0-9]+_[0-9]+` branches; version patch
+  step updated for `pyproject.toml`.
+- `publish-to-pypi.yml`: unchanged semantics (master push → PyPI); version now read from pyproject.
+- README badges: GitHub Actions (tests, docs), PyPI version/downloads/license.
+
+## 8. Docs architecture
+
+- Sphinx + `furo` theme (modern, dark-mode, mobile-friendly; replaces RTD theme), strict `-W` builds.
+- Structure: `index` (framework pitch) → `quickstart` → `concepts/` (processor, config, stats,
+  warm-start) → `components/` → `lambda_api` → `durable` → `tutorials/` → `migration_3_0` →
+  `contribution/` → `deprecated/` (legacy orchestration docs, clearly banner-marked).
+- `AGENTS.md` at repo root for coding agents; `.kiro/steering/{product,tech,structure}.md` for
+  spec-driven sessions.
+
+## 9. Delivery pipeline
+
+Feature branches off `3_0_0`, PR per work stream into `3_0_0` (see tasks.md), each PR:
+implementation (Joshua) → code review posted on the PR (Arkady, via bender-sosw) → merge (ngr commits,
+bender-sosw approval). Final `3_0_0 → master` PR is opened but **left for human approval** — merging it
+publishes 3.0.0 to PyPI.

--- a/.kiro/specs/hq-692-sosw-3-0-0/requirements.md
+++ b/.kiro/specs/hq-692-sosw-3-0-0/requirements.md
@@ -1,0 +1,91 @@
+# sosw 3.0.0 — Requirements
+
+Tracker: SOSW HQ ticket HQ-692 · Target branch: `3_0_0` · Released from `master` merge (auto-publishes to PyPI).
+
+## Vision
+
+sosw 3.0.0 repurposes the package from "Serverless Orchestrator of Serverless Workers" into a
+**framework for bootstrapping AWS Lambda functions**: the `Processor` base class (with warm-start
+container reuse), the AWS middleware components, and the helpers are the product. The legacy
+orchestration layer stays importable but is formally deprecated.
+
+## R1 — Packaging & version
+
+- WHEN the package is built, THE SYSTEM SHALL read all metadata from `pyproject.toml` (setup.py removed or reduced to a shim) with `version = "3.0.0"`.
+- THE SYSTEM SHALL declare support for Python 3.10, 3.11, 3.12, 3.13 and 3.14 in classifiers and `requires-python >= 3.10`.
+- THE SYSTEM SHALL keep `boto3` as the only mandatory runtime dependency.
+- THE SYSTEM SHALL expose optional extras: `sosw[durable]` for the AWS durable execution SDK.
+- WHEN dev dependencies are locked, THE SYSTEM SHALL NOT ship known-vulnerable pins (current Pipfile.lock carries 15 Dependabot alerts; regenerate or remove the lockfile).
+
+## R2 — Deprecation of the orchestration layer
+
+- WHEN a user imports or instantiates `Orchestrator`, `Scavenger`, `Scheduler`, `Worker`, `WorkerAssistant`, `Labourer`, `Essential`, `managers.task.TaskManager`, `managers.ecology.EcologyManager`, or `managers.meta_handler.MetaHandler`, THE SYSTEM SHALL emit a `DeprecationWarning` naming the replacement guidance and the removal horizon (4.0), exactly once per class per process.
+- THE SYSTEM SHALL keep every deprecated entity fully functional in 3.x (no behavior change beyond the warning).
+- `sosw/__init__.py` SHALL become a lazy façade (PEP 562 `__getattr__`) so that `import sosw` does not import orchestration modules or emit warnings, while `from sosw import Orchestrator` still works (with warning).
+- Internal cross-imports (`siblings.py`, `ecology → task`) SHALL NOT trigger the deprecation warnings during normal component use.
+
+## R3 — Processor & warm start (core)
+
+- `Processor`, `LambdaGlobals` and `get_lambda_handler` remain the core public API; `get_lambda_handler` SHALL keep caching the Processor instance across warm invocations.
+- THE SYSTEM SHALL fix the `test` flag operator-precedence bug (`kwargs.get('test') or True if ...`) so an explicit `test=False`/absent flag is honored outside test stages.
+- THE SYSTEM SHALL stop double-calling `reset_stats()` per invocation in the generated handler.
+- WHEN `custom_config` contains `disable_ddb_config: True` (or the Processor attribute `DISABLE_DDB_CONFIG` is set), THE SYSTEM SHALL skip the per-function DynamoDB/SSM config lookup (absorbed from PR #376).
+
+## R4 — lambda_api component
+
+- THE SYSTEM SHALL provide `sosw.lambda_api.LambdaApi(Processor)`: a declarative-router base class for Lambdas behind API Gateway (REST v1 and HTTP v2 payloads).
+- It SHALL support: route table config (`method + path → handler`), Cognito JWT claims extraction (id & access token shapes, numeric and string `exp`), configurable authorization groups, config-driven CORS headers, JSON response envelope with a DynamoDB-aware encoder (Decimal/datetime/set), pre-rendered response passthrough, and an `ApiError` exception hierarchy (400/401/403/404/409/500) in `sosw.components.exceptions`.
+- Auth failures SHALL return 401/403 without leaking claim contents; unknown routes 404; handler exceptions 500 with a machine-readable error envelope and full server-side logging.
+- The component SHALL be fully unit-tested with mocked events (no network), covering the documented test matrix.
+
+## R5 — Durable functions support
+
+- THE SYSTEM SHALL provide `sosw.durable.get_durable_lambda_handler(...)` producing a handler wrapped with the AWS durable execution SDK, reusing the exact non-durable handler behavior (extracted shared builder in `sosw.app`).
+- `import sosw` and `import sosw.app` SHALL NOT import the durable SDK; `sosw.durable` SHALL raise a helpful `ImportError` mentioning `pip install sosw[durable]` when the SDK is missing.
+- SDK-optional helpers SHALL be provided: `durable_wait(seconds)` (falls back to `time.sleep`) and `parse_durable_result(payload)` (unwraps the `{"Status","Result"}` invocation envelope).
+- Unit tests SHALL run with the SDK absent (fake-SDK injection) and assert no SDK leakage into `sosw.app`.
+
+## R6 — Components & helpers tidy-up
+
+- `recursive_matches_extract` SHALL gain the `case_insensitive` option (community PR #379, with credit).
+- `scheduler.py` regex SHALL use a raw string (kills the Python 3.12+ SyntaxWarning).
+- Helpers keep full backward compatibility; docstrings completed where missing.
+
+## R7 — Tests & coverage
+
+- THE SYSTEM SHALL reach and enforce **100% unit-test line coverage** of `sosw/` (test dirs excluded per `.coveragerc`), including both branches of the optional-powertools import guards.
+- All existing orphan test files SHALL be registered in the unit suite or removed; the legacy `components/test/test_config.py` (creates real DynamoDB tables) SHALL stop shadowing the unit variant.
+- The unit suite SHALL stay network-free and complete in well under a minute.
+
+## R8 — CI (GitHub Workflows only)
+
+- PR checks SHALL run: unit tests on a 3.10–3.14 matrix, a coverage job failing under the enforced threshold (100 at release), and a docs build (`sphinx -W`).
+- The TestPyPI RC publish SHALL trigger for `X_Y_Z`-style staging branches (not only `0_*`) and patch the version wherever it lives after the pyproject migration.
+- Travis badges/references SHALL be removed from README and docs; badges point at GitHub Actions.
+- The stray repo-root `.aws/config` SHALL be removed; `.claude/` ignored.
+
+## R9 — Documentation (humans)
+
+- Docs SHALL be rebuilt Sphinx-first with a modern theme, restructured as: quickstart (pip install → first Processor Lambda in minutes), framework concepts (Processor, config, stats, warm start), per-component guides, lambda_api guide, durable guide, tutorials, contribution guide, and a 0.x → 3.0 migration page (orchestration deprecation front and center).
+- Every documented example SHALL match the 3.0 API.
+
+## R10 — Documentation (AI agents)
+
+- The repo SHALL ship `AGENTS.md` (GitHub issue #388) written for coding agents: package map, how to implement a Lambda on sosw, how to test (mock patterns), how to debug, style rules.
+- `.kiro/steering/` SHALL contain product/tech/structure steering docs for spec-driven work in this repo.
+
+## R11 — Bootstrap tooling
+
+- A cookiecutter template SHALL scaffold a new sosw-based Lambda (src/app.py on Processor, unit tests, template.yaml, samconfig.toml, README) with documented usage.
+- A Lambda layer example SHALL ship with autobuild + autodeploy scripts, bundling sosw and optionally (default-on) aws-lambda-powertools and aws-xray-sdk.
+
+## R12 — Community hygiene
+
+- Every open GitHub issue and PR SHALL receive a triage comment from the maintainer account (bender-sosw); obsolete ones closed with reasoning, keepers tagged to the 3.x roadmap.
+- New improvement issues discovered during this release SHALL be filed (typing/mypy, moto-based DDB tests, async story, powertools matrix, etc.).
+
+## Out of scope for 3.0.0
+
+- Removing any deprecated entity (that is 4.0).
+- Async/await support, AthenaManager, and other KEEP-ROADMAP issues (filed/kept for 3.x).
+- Publishing to PyPI from this ticket: happens automatically when a human merges `3_0_0 → master`.

--- a/.kiro/specs/hq-692-sosw-3-0-0/tasks.md
+++ b/.kiro/specs/hq-692-sosw-3-0-0/tasks.md
@@ -1,0 +1,43 @@
+# sosw 3.0.0 — Tasks
+
+Each numbered task = one PR into `3_0_0` unless noted. Requirements references in brackets.
+
+- [ ] 1. CI & repo hygiene (`hq-692-ci-workflows`) [R8, R10-part]
+  - [ ] 1.1 Commit spec (`.kiro/specs/hq-692-sosw-3-0-0/`) and initial `.kiro/steering/` docs
+  - [ ] 1.2 `run-unittests.yml`: 3.10–3.14 matrix + coverage job (`--cov-fail-under`, staged threshold)
+  - [ ] 1.3 `docs-builder-action.yaml`: pip-based, `sphinx-build -W`
+  - [ ] 1.4 `publish-to-test-pypi.yml`: staging-branch pattern `X_Y_Z`, version patch step
+  - [ ] 1.5 README badges → GitHub Actions; remove Travis; drop stray `.aws/config`; gitignore `.claude/`
+- [ ] 2. Deprecations (`hq-692-deprecations`) [R2]
+  - [ ] 2.1 Deprecation helper + warnings in all 10 deprecated classes
+  - [ ] 2.2 `sosw/__init__.py` lazy façade (PEP 562), `siblings.py` import fix
+  - [ ] 2.3 Unit tests: warning emitted once per class, façade lazy, components silent
+- [ ] 3. lambda_api (`hq-692-lambda-api`) [R4]
+  - [ ] 3.1 `ApiError` hierarchy in `components/exceptions.py`
+  - [ ] 3.2 `sosw/lambda_api.py` LambdaApi with router/auth/CORS/encoder/envelope
+  - [ ] 3.3 Full unit test matrix (v1+v2 events, auth paths, errors, CORS, encoder)
+- [ ] 4. Warm start + durable (`hq-692-durable`) [R3, R5]
+  - [ ] 4.1 Extract shared `_make_lambda_handler`; fix `test` precedence; single `reset_stats`; `disable_ddb_config`
+  - [ ] 4.2 `sosw/durable.py` + helpers, import guards
+  - [ ] 4.3 Unit tests incl. fake-SDK injection and no-SDK-leak assertions
+- [ ] 5. Packaging + helpers tidy (`hq-692-packaging`) [R1, R6]
+  - [ ] 5.1 `pyproject.toml` full metadata, version 3.0.0, extras `[durable]`, 3.14 classifier
+  - [ ] 5.2 Pipfile/lock refresh or removal (kill the 15 Dependabot alerts)
+  - [ ] 5.3 `case_insensitive` for `recursive_matches_extract` (PR #379, credited); scheduler raw-string fix
+- [ ] 6. Coverage 100% (`hq-692-coverage`) [R7]
+  - [ ] 6.1 Register orphan tests; retire duplicate legacy test_config
+  - [ ] 6.2 Per-module test authoring to 100% (incl. decorators.py from 0%)
+  - [ ] 6.3 Powertools import-guard branch coverage via module reload technique
+  - [ ] 6.4 Raise CI gate to `--cov-fail-under=100`
+- [ ] 7. Docs rebuild (`hq-692-docs`) [R9]
+  - [ ] 7.1 Theme + structure + quickstart + concepts + component guides
+  - [ ] 7.2 lambda_api + durable guides, tutorials refresh, migration_3_0 page
+  - [ ] 7.3 Deprecated section banner-marked; all examples on 3.0 API
+- [ ] 8. Agent docs & bootstrap tooling (`hq-692-agent-docs`) [R10, R11]
+  - [ ] 8.1 `AGENTS.md` (closes #388) + steering refinement
+  - [ ] 8.2 Cookiecutter template + docs
+  - [ ] 8.3 Layer example with autobuild/autodeploy scripts (powertools/xray default-on)
+- [ ] 9. GitHub triage (no PR) [R12]
+  - [ ] 9.1 Triage comments on all open issues/PRs as bender-sosw; close obsolete
+  - [ ] 9.2 File new improvement issues
+- [ ] 10. Release PR `3_0_0 → master` — open, changelog, DO NOT merge (human gate)

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,34 @@
+# Product — sosw
+
+`sosw` (PyPI: `sosw`) is a **Python framework for bootstrapping AWS Lambda functions**.
+
+It gives every Lambda a common backbone:
+
+- `sosw.app.Processor` — a base class with layered configuration (defaults → DynamoDB/SSM config →
+  custom config), statistics collection, lazy AWS client registration, and container warm-start reuse
+  via `LambdaGlobals` / `get_lambda_handler`.
+- `sosw.lambda_api.LambdaApi` — a Processor for HTTP APIs behind API Gateway: declarative routing,
+  Cognito claims handling, CORS, JSON envelopes, typed API errors.
+- `sosw.durable` — optional integration with AWS Lambda durable execution (`pip install sosw[durable]`).
+- `sosw.components` — thin, well-tested middleware for AWS services (DynamoDB, SNS, Secrets/Config,
+  SigV4 signing, siblings) plus battle-tested helpers.
+
+## History and positioning
+
+Until 2.x the package was the "Serverless Orchestrator of Serverless Workers" — a self-hosted
+orchestration suite (Orchestrator, Scheduler, Scavenger, Worker…). Since **3.0.0** those orchestration
+entities are **deprecated** (functional through 3.x, removed in 4.0): AWS-native services
+(Step Functions, EventBridge, durable execution) now cover that ground. The framework core —
+Processor, components, helpers — is the product.
+
+## Users
+
+- Engineering teams standardizing many small Lambdas on one config/stats/testing pattern.
+- AI coding agents scaffolding new Lambdas (see `AGENTS.md` and the cookiecutter template).
+
+## Quality bars
+
+- 100% unit test line coverage, enforced in CI. Unit suite is network-free and fast (seconds).
+- Zero mandatory dependencies beyond `boto3`.
+- Python 3.10–3.14.
+- Docs at https://docs.sosw.app must build warning-free.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,37 @@
+# Structure — sosw repository
+
+```
+sosw/                     # the package
+├── __init__.py           # lazy façade (PEP 562) — public names resolve on demand
+├── app.py                # CORE: Processor, LambdaGlobals, get_lambda_handler
+├── lambda_api.py         # CORE: LambdaApi(Processor) for API Gateway Lambdas
+├── durable.py            # CORE (optional dep): durable execution handler factory + helpers
+├── _deprecation.py       # internal deprecation warning helper
+├── components/           # AWS middleware + helpers (kept, 100% covered)
+│   ├── benchmark.py config.py decorators.py dynamo_db.py exceptions.py
+│   ├── helpers.py siblings.py sigv4.py sns.py
+│   └── test/unit/        # component unit tests (+ legacy integration/ — not in CI)
+├── managers/             # DEPRECATED orchestration managers (task, ecology, meta_handler)
+├── orchestrator.py scavenger.py scheduler.py worker.py worker_assistant.py
+│                         # DEPRECATED orchestration entities (removed in 4.0)
+├── labourer.py essential.py   # DEPRECATED
+└── test/
+    ├── suite_unit.py     # THE unit suite — every unit test file must be imported here
+    ├── unit/             # core unit tests
+    ├── integration/      # requires real AWS, not in CI
+    └── variables.py, helpers_test*.py  # shared fixtures/mocks
+
+docs/                     # Sphinx documentation (docs.sosw.app), built with -W in CI
+examples/                 # runnable examples (SAM, workers, layers, cookiecutter usage)
+.github/workflows/        # Tests / Docs / TestPyPI RC / PyPI release
+.kiro/specs/              # feature specs (requirements/design/tasks) — committed
+.kiro/steering/           # this steering set
+AGENTS.md                 # instructions for AI coding agents working on/with sosw
+```
+
+## Rules of the road
+
+- New unit test file → import it in `sosw/test/suite_unit.py` or CI never sees it.
+- Deprecated modules: bugfixes only; no new features; do not remove before 4.0.
+- Public API changes require a spec under `.kiro/specs/` and a docs update in the same release.
+- `examples/` content must actually run against the published package version it ships with.

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,39 @@
+# Tech standards — sosw
+
+## Language & dependencies
+
+- Python 3.10–3.14. Runtime dependency: `boto3` only. Optional extras: `sosw[durable]`.
+- Never add a mandatory dependency without a maintainer decision recorded in an issue.
+- Packaging via `pyproject.toml` (PEP 621, setuptools backend). Version lives there.
+
+## Code style (PRs are bounced on violations)
+
+- PEP-8 with **two blank lines** between functions/methods/classes; vertically aligned dict values.
+- **Single quotes** for regular strings and dict keys; **double quotes** for logging and exception
+  messages.
+- Logging always `logger.info("... %s", var)` — **never f-strings in log calls**.
+- Imports at the top, grouped: full core imports, full custom imports, partial core, partial custom.
+- No `try/except: pass` around business logic. Fail fast and loud — Lambdas must raise on errors.
+- snake_case for data fields in events/payloads/records.
+- reST docstrings (`:param x:`, `:rtype:`) on all public callables; modules start with the MIT license
+  header docstring (copy from `sosw/app.py`).
+- Every file ends with exactly one newline.
+
+## Testing
+
+- `unittest.TestCase` style; unit tests live in `*/test/unit/` and MUST be registered in
+  `sosw/test/suite_unit.py` (explicit suite — pytest discovery is NOT used in CI).
+- Unit tests are pure: mock boto3 (`patch('boto3.client')`, `MagicMock` clients,
+  `patch.object(Processor, 'get_config')`). No network, no real AWS, no sleeps.
+- Integration tests (`*/test/integration/`) require real AWS and are NOT run in CI.
+- Do not run `pytest sosw/` over the whole tree — legacy integration files create real DynamoDB tables.
+- Coverage: 100% of `sosw/` (test dirs excluded via `.coveragerc`), enforced with
+  `--cov-fail-under` in CI. Cover optional-import guards by reloading modules with a patched
+  `sys.modules`, not with `# pragma: no cover`.
+
+## CI/CD
+
+- GitHub Workflows only (Travis is gone): Tests matrix 3.10–3.14 + coverage job, Docs build (Sphinx),
+  TestPyPI RC publish on staging branches (`X_Y_Z`), PyPI publish on push to `master`.
+- Staging-branch flow: feature branches → PR into the current `X_Y_Z` staging branch → release PR
+  `X_Y_Z → master`. Merging to master publishes to PyPI.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img alt="sosw - Serverless Orchestrator of Serverless Workers" width="350" src="https://raw.githubusercontent.com/sosw/sosw/docme/docs/_static/images/logo/sosw_black.png">
 
 # Serverless Orchestrator of Serverless Workers
-[![Build Status](https://travis-ci.com/sosw/sosw.svg?branch=master)](https://travis-ci.com/sosw/sosw)
-![Documentation Status](https://img.shields.io/docsrs/docs)
+[![Tests](https://github.com/sosw/sosw/actions/workflows/run-unittests.yml/badge.svg)](https://github.com/sosw/sosw/actions/workflows/run-unittests.yml)
+[![Docs](https://github.com/sosw/sosw/actions/workflows/docs-builder-action.yaml/badge.svg)](https://github.com/sosw/sosw/actions/workflows/docs-builder-action.yaml)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/sosw?color=blue&label=pypi%20installs)](https://pypi.org/project/sosw/)
 [![PyPI - Licence](https://img.shields.io/pypi/l/sosw?color=blue)](https://github.com/sosw/sosw/blob/master/LICENSE)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,12 +4,12 @@
 Serverless Orchestrator of Serverless Workers
 =============================================
 
-..  image:: https://travis-ci.com/sosw/sosw.svg?branch=master
-    :alt: Travis - Build
-    :target: https://travis-ci.com/sosw/sosw
-..  image:: https://img.shields.io/docsrs/docs
-    :alt: Documentation Status
-    :target: https://docs.sosw.app/?badge=latest
+..  image:: https://github.com/sosw/sosw/actions/workflows/run-unittests.yml/badge.svg
+    :alt: Tests
+    :target: https://github.com/sosw/sosw/actions/workflows/run-unittests.yml
+..  image:: https://github.com/sosw/sosw/actions/workflows/docs-builder-action.yaml/badge.svg
+    :alt: Docs
+    :target: https://github.com/sosw/sosw/actions/workflows/docs-builder-action.yaml
 ..  image:: _static/images/coverage.svg
     :alt: Test Coverage
     :target: https://docs.sosw.app/?badge=latest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,34 +1,7 @@
-alabaster
-ApiDoc
-autodoc
-Babel
-beautifulsoup4
+# Requirements for building the documentation (see docs/conf.py and the Docs workflow).
+# boto3 is needed because conf.py imports sosw for autodoc, and sosw requires boto3.
+# The sphinx.ext.* extensions ship with Sphinx itself; docs.ext.hidden_code_block is local.
 boto3
-botocore
-certifi
-chardet
-decorator
-docutils
-idna
-imagesize
-Jinja2
-jmespath
-jsonschema
-MarkupSafe
-packaging
-Pygments
-pyparsing
-python-dateutil
-pytz
-PyYAML
-requests
-s3transfer
-six
-snowballstemmer
-Sphinx
-sphinxcontrib-websupport
+sphinx
+sphinx-rtd-theme
 sphinx-sitemap
-urllib3
-waitress
-WebOb
-WebTest


### PR DESCRIPTION
Part of the **sosw 3.0.0** release (staging branch `3_0_0`). Spec: `.kiro/specs/hq-692-sosw-3-0-0/`.

## What
- **Tests workflow**: unit matrix **3.10–3.14** (was 3.10–3.13) + a dedicated **coverage job** with `--cov-fail-under=75` — staged threshold, raised to 100 by the coverage work stream. Local run: `267 passed, 2 skipped`, coverage 76.52%.
- **Docs workflow**: pip-based install from a fixed `docs/requirements.txt` (the old file was CI-unusable: missing `sphinx_rtd_theme`, and a junk `autodoc` pin dragging Python-2-era Jinja2). Build verified **clean under `-W`** in a fresh venv, so warnings-as-errors ships on.
- **Fix #267 — RC publishing was dead**: `publish-to-test-pypi.yml` triggered on `pull_request`, but its publish steps guarded on `refs/heads/0_*` which never matches PR merge refs. Now triggers on **push to staging branches** (`[0-9]*_*` — matches `0_7_51`, `3_0_0`, not `master`), and the version-patch step handles both `setup.py` (today) and `pyproject.toml` (after the packaging stream), PEP 440 `rc<unix-ts>` suffix. Tested in sandboxes for current/future/neither file states.
- **README badges**: dead Travis + wrong docsrs (a Rust service) removed; GitHub Actions Tests/Docs badges added.
- **Hygiene**: stray committed `.aws/config` removed (unreferenced — grep-verified); `.claude/` gitignored; `.kiro/` spec + steering committed.

## Verification
- All 4 workflow YAMLs parse (`yaml.safe_load`).
- Unit suite green after every change.
- Coverage job command executed exactly as CI runs it: `Required test coverage of 75% reached. Total coverage: 76.52%`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)