### PR TITLE
3.0.0: deprecate the orchestration layer (work stream 2)

### DIFF
--- a/sosw/__init__.py
+++ b/sosw/__init__.py
@@ -1,4 +1,103 @@
-from .app import Processor
-from .worker import Worker
-from .orchestrator import Orchestrator
-from .essential import Essential
+"""
+..  hidden-code-block:: text
+    :label: View Licence Agreement <br>
+
+    sosw - Serverless Orchestrator of Serverless Workers
+
+    The MIT License (MIT)
+    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+``sosw`` - a framework for bootstrapping AWS Lambda functions.
+
+This package init is a lazy façade (:pep:`562`): ``import sosw`` imports neither ``boto3`` nor any
+package modules and emits no warnings. Public names (e.g. ``sosw.Processor``) are resolved and
+cached on first attribute access. The deprecated orchestration entities remain importable for
+backwards compatibility, but emit a ``DeprecationWarning`` when instantiated. They will be removed
+in ``sosw`` 4.0. See the migration guide: https://docs.sosw.app/migration_3_0.html
+"""
+
+__all__ = [
+    'Processor',
+    'LambdaGlobals',
+    'get_lambda_handler',
+    'Essential',
+    'Labourer',
+    'Orchestrator',
+    'Scavenger',
+    'Scheduler',
+    'Worker',
+    'WorkerAssistant',
+]
+
+from importlib import import_module
+
+
+# Public package attributes are imported lazily from these modules on first access (PEP 562).
+_LAZY_ATTRIBUTES = {
+    'Processor':          'sosw.app',
+    'LambdaGlobals':      'sosw.app',
+    'get_lambda_handler': 'sosw.app',
+    'Essential':          'sosw.essential',
+    'Labourer':           'sosw.labourer',
+    'Orchestrator':       'sosw.orchestrator',
+    'Scavenger':          'sosw.scavenger',
+    'Scheduler':          'sosw.scheduler',
+    'Worker':             'sosw.worker',
+    'WorkerAssistant':    'sosw.worker_assistant',
+}
+
+
+def _get_version() -> str:
+    """
+    Version of the installed ``sosw`` distribution, or the release default when running from sources.
+
+    :rtype: str
+    """
+
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version('sosw')
+    except PackageNotFoundError:
+        return '3.0.0'
+
+
+def __getattr__(name):
+    """
+    Resolve public attributes lazily (PEP 562), keeping ``import sosw`` free of heavy imports.
+
+    :param str name:        Name of the requested package attribute.
+    :raises AttributeError: If the name is not a public attribute of the package.
+    """
+
+    if name == '__version__':
+        value = _get_version()
+    elif name in _LAZY_ATTRIBUTES:
+        value = getattr(import_module(_LAZY_ATTRIBUTES[name]), name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = value  # Cache, so that the next access does not call `__getattr__` again.
+    return value
+
+
+def __dir__():
+    return sorted([*__all__, '__version__'])

--- a/sosw/_deprecation.py
+++ b/sosw/_deprecation.py
@@ -1,0 +1,78 @@
+"""
+..  hidden-code-block:: text
+    :label: View Licence Agreement <br>
+
+    sosw - Serverless Orchestrator of Serverless Workers
+
+    The MIT License (MIT)
+    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+Internal helper emitting ``DeprecationWarning`` for the legacy orchestration entities of ``sosw``.
+
+Since version 3.0.0 ``sosw`` is a framework for bootstrapping AWS Lambda functions. The orchestration
+layer (Orchestrator, Scheduler, Scavenger, Worker, etc.) is deprecated: it stays fully functional
+throughout 3.x, warns once per entity per process when instantiated, and will be removed in 4.0.
+"""
+
+__all__ = ['warn_deprecated', 'reset_warned_entities']
+__author__ = "Nikolay Grishchenko"
+
+import warnings
+
+
+MIGRATION_GUIDE_URL = 'https://docs.sosw.app/migration_3_0.html'
+
+# Names of entities that have already warned in this process. See `warn_deprecated`.
+_WARNED_ENTITIES = set()
+
+
+def warn_deprecated(entity_name: str, hint: str = ''):
+    """
+    Emit a ``DeprecationWarning`` for a deprecated ``sosw`` entity, once per `entity_name` per process.
+
+    Designed to be called as the very first statement of the ``__init__`` of a deprecated class.
+    The ``stacklevel=3`` then attributes the warning to the line of user code constructing the object:
+    user code -> ``SomeDeprecatedClass.__init__`` -> ``warn_deprecated`` -> ``warnings.warn``.
+
+    :param str entity_name: Name of the deprecated entity, e.g. ``'Orchestrator'``.
+    :param str hint:        Optional entity-specific migration guidance injected into the message.
+    """
+
+    if entity_name in _WARNED_ENTITIES:
+        return
+
+    _WARNED_ENTITIES.add(entity_name)
+
+    message = f"{entity_name} is deprecated since sosw 3.0.0 and will be removed in 4.0."
+    if hint:
+        message += f" {hint}"
+    message += f" sosw is now a Lambda bootstrapping framework; see the migration guide: {MIGRATION_GUIDE_URL}"
+
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+
+def reset_warned_entities():
+    """
+    Clear the once-per-process guard so that deprecated entities may warn again.
+    Intended primarily for tests.
+    """
+
+    _WARNED_ENTITIES.clear()

--- a/sosw/components/siblings.py
+++ b/sosw/components/siblings.py
@@ -47,7 +47,7 @@ import json
 import os
 
 from math import ceil
-from sosw import Processor
+from sosw.app import Processor
 
 
 class SiblingsManager(Processor):

--- a/sosw/essential.py
+++ b/sosw/essential.py
@@ -43,6 +43,7 @@ except ImportError:
 
 import os
 
+from sosw._deprecation import warn_deprecated
 from sosw.app import Processor
 from sosw.components.helpers import recursive_update
 from sosw.managers.meta_handler import MetaHandler
@@ -55,6 +56,11 @@ class Essential(Processor):
     Currently implemented:
 
     * Update the ``self.config`` with shared settings (e.g list of registered Labourers)
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Inherit your Lambdas directly
+        from :ref:`Processor` (``sosw.app.Processor``) instead.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     meta_handler: MetaHandler = None
@@ -62,6 +68,7 @@ class Essential(Processor):
 
     def __init__(self, *args, **kwargs):
 
+        warn_deprecated('Essential', hint="Inherit your Lambdas directly from sosw.app.Processor instead.")
         super().__init__(*args, **kwargs)
 
         self.meta_handler = MetaHandler(custom_config=self.config.get('meta_handler_config'))

--- a/sosw/labourer.py
+++ b/sosw/labourer.py
@@ -45,8 +45,18 @@ except ImportError:
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
 
+from sosw._deprecation import warn_deprecated
+
 
 class Labourer:
+    """
+    Settings container describing a type of Workers of the ``sosw`` orchestration model.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0 together with the orchestration entities
+        it describes. See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
+    """
+
     ATTRIBUTES = ('id', 'arn')
     CUSTOM_ATTRIBUTES = ('arn', 'start', 'invoked', 'expired', 'health', 'health_metrics', 'average_duration',
                          'max_duration', 'max_attempts', 'max_simultaneous_invocations')
@@ -60,6 +70,10 @@ class Labourer:
 
 
     def __init__(self, **kwargs):
+
+        warn_deprecated('Labourer',
+                        hint="Labourer describes workers of the deprecated sosw orchestration model "
+                             "and has no replacement.")
 
         if kwargs.pop('strict', False):
             for k, v in kwargs.items():

--- a/sosw/managers/ecology.py
+++ b/sosw/managers/ecology.py
@@ -54,6 +54,7 @@ from collections import OrderedDict
 from statistics import mean
 from typing import Dict, List, Optional, Union
 
+from sosw._deprecation import warn_deprecated
 from sosw.app import Processor
 from sosw.labourer import Labourer
 from sosw.components.benchmark import benchmark
@@ -71,6 +72,15 @@ ECO_STATUSES = (
 
 
 class EcologyManager(Processor):
+    """
+    Manages the health status (ecology) of Labourers based on CloudWatch metrics and running tasks.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use CloudWatch alarms and AWS-native
+        auto scaling or throttling controls to protect your resources.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
+    """
+
     DEFAULT_CONFIG = {
         'init_clients': ['cloudwatch'],
         'default_metric_values':
@@ -88,6 +98,9 @@ class EcologyManager(Processor):
 
 
     def __init__(self, *args, **kwargs):
+        warn_deprecated('EcologyManager',
+                        hint="Use CloudWatch alarms and AWS-native auto scaling or throttling controls "
+                             "to protect your resources.")
         super().__init__(*args, **kwargs)
 
 

--- a/sosw/managers/meta_handler.py
+++ b/sosw/managers/meta_handler.py
@@ -44,6 +44,7 @@ except ImportError:
 import time
 
 
+from sosw._deprecation import warn_deprecated
 from sosw.app import global_vars
 from sosw.components.dynamo_db import DynamoDbClient
 from sosw.components.helpers import recursive_update
@@ -54,6 +55,11 @@ class MetaHandler:
     """
     MetaHandler is helper class for Essential classes.
     It works with DynamoDB table to store the meta data of operations on Tasks.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Record audit trails of your workflows
+        directly to DynamoDB or CloudWatch instead.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -88,6 +94,10 @@ class MetaHandler:
     }
 
     def __init__(self, custom_config: Dict = None, **kwargs):
+
+        warn_deprecated('MetaHandler',
+                        hint="Record audit trails of your workflows directly to DynamoDB "
+                             "or CloudWatch instead.")
 
         # Initialize config from default config
         self.config = self.DEFAULT_CONFIG or {}

--- a/sosw/managers/task.py
+++ b/sosw/managers/task.py
@@ -50,6 +50,7 @@ from copy import deepcopy
 from json.decoder import JSONDecodeError
 from typing import Dict, List, Optional, Union
 
+from sosw._deprecation import warn_deprecated
 from sosw.app import Processor
 from sosw.components.benchmark import benchmark
 from sosw.components.dynamo_db import DynamoDbClient
@@ -68,6 +69,10 @@ class TaskManager(Processor):
 
     The very important concept to understand about Task workflow is `greenfield`. :ref:`Read more <greenfield>`.
 
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use AWS-native services
+        (SQS, Step Functions) to manage queues of tasks.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -147,6 +152,12 @@ class TaskManager(Processor):
     ecology_client = None
     dynamo_db_client: DynamoDbClient = None
     lambda_client: boto3.client = None
+
+
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('TaskManager',
+                        hint="Use AWS-native services (SQS, Step Functions) to manage queues of tasks.")
+        super().__init__(*args, **kwargs)
 
 
     def get_oldest_greenfield_for_labourer(self, labourer: Labourer, reverse: bool = False) -> int:

--- a/sosw/orchestrator.py
+++ b/sosw/orchestrator.py
@@ -45,6 +45,7 @@ import math
 
 from typing import List
 
+from sosw._deprecation import warn_deprecated
 from sosw.essential import Essential
 from sosw.labourer import Labourer
 from sosw.managers.task import TaskManager
@@ -54,6 +55,11 @@ class Orchestrator(Essential):
     """
     | Orchestrator class.
     | Iterates the pre-configured Labourers and invokes appropriate number of Tasks for each one.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use AWS Step Functions or Amazon EventBridge
+        to orchestrate your Lambdas, or AWS Lambda durable functions for long-running workflows.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -69,6 +75,13 @@ class Orchestrator(Essential):
     }
 
     task_client: TaskManager = None
+
+
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('Orchestrator',
+                        hint="Use AWS Step Functions or Amazon EventBridge to orchestrate your Lambdas, "
+                             "or AWS Lambda durable functions for long-running workflows.")
+        super().__init__(*args, **kwargs)
 
 
     def __call__(self, event):

--- a/sosw/scavenger.py
+++ b/sosw/scavenger.py
@@ -43,6 +43,7 @@ except ImportError:
 
 from typing import Dict
 
+from sosw._deprecation import warn_deprecated
 from sosw.essential import Essential
 from sosw.labourer import Labourer
 from sosw.managers.task import TaskManager
@@ -55,6 +56,11 @@ class Scavenger(Essential):
     - archive_tasks(labourer)
     - handle_expired_tasks(labourer)
     - retry_tasks(labourer)
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use AWS Step Functions error handling
+        or SQS dead-letter queues to retry and archive failed tasks.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -69,6 +75,13 @@ class Scavenger(Essential):
     # these clients will be initialized by Processor constructor
     task_client: TaskManager = None
     sns_client = None
+
+
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('Scavenger',
+                        hint="Use AWS Step Functions error handling or SQS dead-letter queues "
+                             "to retry and archive failed tasks.")
+        super().__init__(*args, **kwargs)
 
 
     def __call__(self, *args, **kwargs):

--- a/sosw/scheduler.py
+++ b/sosw/scheduler.py
@@ -51,6 +51,7 @@ from typing import Iterable
 from copy import deepcopy
 from typing import List, Set, Tuple, Union, Optional, Dict
 
+from sosw._deprecation import warn_deprecated
 from sosw.essential import Essential
 from sosw.app import LambdaGlobals
 from sosw.components.helpers import get_list_of_multiple_or_one_or_empty_from_dict, trim_arn_to_name, chunks
@@ -86,6 +87,10 @@ class Scheduler(Essential):
     values of this parameter are simple strings/integers the scheduler shall chunk them in batches of given size.
     By default will chunk to 1kk objects in a list.
 
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use Amazon EventBridge Scheduler
+        or AWS Step Functions to schedule and chunk your jobs.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -126,6 +131,9 @@ class Scheduler(Essential):
 
     def __init__(self, *args, **kwargs):
 
+        warn_deprecated('Scheduler',
+                        hint="Use Amazon EventBridge Scheduler or AWS Step Functions to schedule "
+                             "and chunk your jobs.")
         super().__init__(*args, **kwargs)
 
         self.set_queue_file()

--- a/sosw/test/suite_unit.py
+++ b/sosw/test/suite_unit.py
@@ -1,5 +1,6 @@
 # Core applications
 from .unit.test_app import app_UnitTestCase
+from .unit.test_deprecations import Deprecations_UnitTestCase
 from .unit.test_labourer import Labourer_UnitTestCase
 from .unit.test_orchestrator import Orchestrator_UnitTestCase
 from .unit.test_scavenger import Scavenger_UnitTestCase
@@ -25,6 +26,7 @@ def suite():
 
     # Core applications
     test_suite.addTest(unittest.makeSuite(app_UnitTestCase))
+    test_suite.addTest(unittest.makeSuite(Deprecations_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Labourer_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Orchestrator_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Scavenger_UnitTestCase))

--- a/sosw/test/unit/test_deprecations.py
+++ b/sosw/test/unit/test_deprecations.py
@@ -1,0 +1,266 @@
+"""
+Unit tests for the ``sosw`` 3.0.0 deprecation mechanics.
+
+Covers the ``sosw._deprecation`` helper (once-per-entity guard), the ``DeprecationWarning``
+emitted on instantiation of every deprecated orchestration entity, and the lazy package
+façade in ``sosw/__init__.py`` (PEP 562).
+"""
+
+import os
+import subprocess
+import sys
+import types
+import unittest
+import warnings
+
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+os.environ["STAGE"] = "test"
+os.environ["autotest"] = "True"
+
+import sosw
+
+from sosw._deprecation import MIGRATION_GUIDE_URL, reset_warned_entities, warn_deprecated
+from sosw.app import LambdaGlobals, Processor, global_vars
+from sosw.essential import Essential
+from sosw.labourer import Labourer
+from sosw.managers.ecology import EcologyManager
+from sosw.managers.meta_handler import MetaHandler
+from sosw.managers.task import TaskManager
+from sosw.orchestrator import Orchestrator
+from sosw.scavenger import Scavenger
+from sosw.scheduler import Scheduler
+from sosw.worker import Worker
+from sosw.worker_assistant import WorkerAssistant
+from sosw.test.variables import TEST_ECOLOGY_CLIENT_CONFIG, TEST_ESSENTIAL_CONFIG, TEST_META_HANDLER_CONFIG, \
+    TEST_ORCHESTRATOR_CONFIG, TEST_SCAVENGER_CONFIG, TEST_SCHEDULER_CONFIG, TEST_TASK_CLIENT_CONFIG, \
+    TEST_WORKER_ASSISTANT_CONFIG
+
+
+class Deprecations_UnitTestCase(unittest.TestCase):
+
+    def setUp(self):
+        reset_warned_entities()
+
+        self.patcher = patch("sosw.app.get_config")
+        self.get_config_patch = self.patcher.start()
+        self.get_config_patch.return_value = {}
+
+
+    def tearDown(self):
+        self.patcher.stop()
+        reset_warned_entities()
+
+        # global_vars.processor is a property that refers to another global. So we have to reset it explicitly.
+        global global_vars
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        try:
+            del (os.environ['AWS_LAMBDA_FUNCTION_NAME'])
+        except Exception:
+            pass
+
+
+    @staticmethod
+    def catch_deprecations(factory):
+        """
+        Call the `factory` and return its result together with the recorded DeprecationWarnings.
+        """
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            result = factory()
+
+        return result, [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+    def assert_warned_deprecation(self, caught, entity_name):
+        """
+        Assert that exactly one recorded warning deprecates `entity_name` with the standard message.
+        """
+
+        messages = [str(w.message) for w in caught]
+        matching = [m for m in messages if m.startswith(f"{entity_name} is deprecated since sosw 3.0.0")]
+
+        self.assertEqual(1, len(matching),
+                         f"Expected exactly one DeprecationWarning for {entity_name}, caught: {messages}")
+        self.assertIn('will be removed in 4.0', matching[0])
+        self.assertIn(MIGRATION_GUIDE_URL, matching[0])
+
+
+    # The `warn_deprecated` helper itself.
+    def test_warn_deprecated__warns_once_per_entity(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            warn_deprecated('SomeEntity')
+            warn_deprecated('SomeEntity')
+            warn_deprecated('AnotherEntity')
+
+        messages = [str(w.message) for w in caught]
+        self.assertEqual(2, len(messages), messages)
+        self.assertTrue(messages[0].startswith('SomeEntity is deprecated since sosw 3.0.0'))
+        self.assertTrue(messages[1].startswith('AnotherEntity is deprecated since sosw 3.0.0'))
+
+
+    def test_warn_deprecated__includes_hint(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            warn_deprecated('SomeEntity', hint='Use something else instead.')
+
+        self.assertIn('Use something else instead.', str(caught[0].message))
+
+
+    def test_reset_warned_entities__allows_rewarning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            warn_deprecated('SomeEntity')
+            reset_warned_entities()
+            warn_deprecated('SomeEntity')
+
+        self.assertEqual(2, len(caught))
+
+
+    # Every deprecated entity warns on instantiation.
+    def test_orchestrator__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(
+                    lambda: Orchestrator(custom_config=deepcopy(TEST_ORCHESTRATOR_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'Orchestrator')
+
+
+    def test_scavenger__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: Scavenger(custom_config=deepcopy(TEST_SCAVENGER_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'Scavenger')
+
+
+    def test_scheduler__warns_on_init(self):
+        lambda_context = types.SimpleNamespace()
+        lambda_context.aws_request_id = 'AWS_REQ_ID'
+        lambda_context.invoked_function_arn = 'arn:aws:lambda:us-west-2:000000000000:function:some_function'
+        lambda_context.get_remaining_time_in_millis = MagicMock(return_value=300000)
+        global_vars.lambda_context = lambda_context
+
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: Scheduler(custom_config=deepcopy(TEST_SCHEDULER_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'Scheduler')
+
+
+    def test_worker__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: Worker())
+
+        self.assert_warned_deprecation(caught, 'Worker')
+
+
+    def test_worker_assistant__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(
+                    lambda: WorkerAssistant(custom_config=deepcopy(TEST_WORKER_ASSISTANT_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'WorkerAssistant')
+
+
+    def test_labourer__warns_on_init(self):
+        _, caught = self.catch_deprecations(lambda: Labourer(id=42, arn='arn::aws::lambda'))
+
+        self.assert_warned_deprecation(caught, 'Labourer')
+
+
+    def test_essential__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: Essential(custom_config=deepcopy(TEST_ESSENTIAL_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'Essential')
+
+
+    def test_task_manager__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: TaskManager(custom_config=deepcopy(TEST_TASK_CLIENT_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'TaskManager')
+
+
+    def test_ecology_manager__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(
+                    lambda: EcologyManager(custom_config=deepcopy(TEST_ECOLOGY_CLIENT_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'EcologyManager')
+
+
+    def test_meta_handler__warns_on_init(self):
+        with patch('boto3.client'):
+            _, caught = self.catch_deprecations(lambda: MetaHandler(custom_config=deepcopy(TEST_META_HANDLER_CONFIG)))
+
+        self.assert_warned_deprecation(caught, 'MetaHandler')
+
+
+    def test_second_instantiation__does_not_rewarn(self):
+        _, first = self.catch_deprecations(lambda: Labourer(id=42, arn='arn::aws::lambda'))
+        self.assert_warned_deprecation(first, 'Labourer')
+
+        _, second = self.catch_deprecations(lambda: Labourer(id=42, arn='arn::aws::lambda'))
+        self.assertEqual([], [str(w.message) for w in second], "Once-guard failed: second instantiation re-warned")
+
+
+    # The lazy package façade.
+    def test_import_sosw__lazy_and_warning_free(self):
+        """
+        ``import sosw`` must emit no warnings and must import neither ``boto3`` nor the orchestration
+        modules. Verified in a subprocess to get a clean interpreter without ``sosw`` pre-imported.
+        """
+
+        code = ("import sys, warnings; warnings.simplefilter('error'); import sosw; "
+                "assert 'sosw.orchestrator' not in sys.modules, 'sosw.orchestrator imported eagerly'; "
+                "assert 'boto3' not in sys.modules, 'boto3 imported eagerly'")
+
+        result = subprocess.run([sys.executable, '-c', code], cwd=Path(__file__).resolve().parents[3],
+                                capture_output=True, text=True, timeout=120)
+
+        self.assertEqual(0, result.returncode, f"Subprocess failed: {result.stderr}")
+
+
+    def test_facade__from_sosw_import_processor(self):
+        from sosw import Processor as facade_processor
+
+        self.assertIs(Processor, facade_processor)
+
+
+    def test_facade__resolves_names_without_warnings(self):
+        for name, expected in [('Processor', Processor), ('Orchestrator', Orchestrator), ('Worker', Worker),
+                               ('Essential', Essential), ('Labourer', Labourer)]:
+            with self.subTest(name=name):
+                resolved, caught = self.catch_deprecations(lambda n=name: getattr(sosw, n))
+
+                self.assertIs(expected, resolved)
+                self.assertEqual([], [str(w.message) for w in caught],
+                                 f"Resolving sosw.{name} must not warn before instantiation")
+
+
+    def test_facade__unknown_attribute_raises(self):
+        self.assertRaises(AttributeError, getattr, sosw, 'NoSuchAttribute')
+
+
+    def test_facade__dir_contains_public_names(self):
+        names = dir(sosw)
+
+        for name in ['Processor', 'LambdaGlobals', 'get_lambda_handler', 'Essential', 'Labourer', 'Orchestrator',
+                     'Scavenger', 'Scheduler', 'Worker', 'WorkerAssistant', '__version__']:
+            self.assertIn(name, names)
+
+
+    def test_version__is_string(self):
+        self.assertIsInstance(sosw.__version__, str)
+        self.assertTrue(len(sosw.__version__) > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sosw/worker.py
+++ b/sosw/worker.py
@@ -43,6 +43,7 @@ except ImportError:
 
 import json
 
+from sosw._deprecation import warn_deprecated
 from sosw.app import Processor
 from sosw.managers.meta_handler import MetaHandler
 from typing import Dict
@@ -64,6 +65,11 @@ class Worker(Processor):
     You also need to grant write permissions for this table to your Lambda.
 
     You can find more information about the configuration in the :ref:`MetaHandler<meta_handler>` chapter.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Inherit your Lambdas directly
+        from :ref:`Processor` (``sosw.app.Processor``) instead.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -77,6 +83,7 @@ class Worker(Processor):
 
     def __init__(self, *args, **kwargs):
 
+        warn_deprecated('Worker', hint="Inherit your Lambdas directly from sosw.app.Processor instead.")
         super().__init__(*args, **kwargs)
 
         if 'meta_handler_config' in self.config:

--- a/sosw/worker_assistant.py
+++ b/sosw/worker_assistant.py
@@ -35,6 +35,7 @@ __version__ = "1.0"
 import json
 import time
 
+from sosw._deprecation import warn_deprecated
 from sosw.essential import Essential
 from sosw.components.dynamo_db import DynamoDbClient
 from sosw.components.helpers import get_one_from_dict
@@ -52,6 +53,11 @@ class WorkerAssistant(Essential):
     Should pass the ``action`` and ``task_id`` attributes in the payload of the call.
 
     See example of the usage in :ref:`Worker`.
+
+    ..  deprecated:: 3.0.0
+        Deprecated since ``sosw`` 3.0.0, will be removed in 4.0. Use the callbacks of your orchestration
+        engine instead, e.g. AWS Step Functions ``SendTaskSuccess`` / ``SendTaskFailure``.
+        See the `migration guide <https://docs.sosw.app/migration_3_0.html>`_.
     """
 
     DEFAULT_CONFIG = {
@@ -81,6 +87,13 @@ class WorkerAssistant(Essential):
 
     # these clients will be initialized by Processor constructor
     dynamo_db_client: DynamoDbClient = None
+
+
+    def __init__(self, *args, **kwargs):
+        warn_deprecated('WorkerAssistant',
+                        hint="Use the callbacks of your orchestration engine instead, "
+                             "e.g. AWS Step Functions SendTaskSuccess / SendTaskFailure.")
+        super().__init__(*args, **kwargs)
 
 
     def __call__(self, event):


### PR DESCRIPTION
Part of the **sosw 3.0.0** release. Spec: `.kiro/specs/hq-692-sosw-3-0-0/` (R2, design §2).

## What
sosw 3.0 repositions the package as a **Lambda bootstrapping framework**; the self-hosted orchestration suite is formally deprecated (fully functional through 3.x, removed in 4.0):

- **`sosw/_deprecation.py`**: `warn_deprecated(entity, hint)` — `DeprecationWarning` with a once-per-process guard, `stacklevel` tuned so the user's construction line is attributed, migration-guide link, and a public `reset_warned_entities()` for tests.
- **Warnings on instantiation** (not import) of the 10 orchestration entities: Orchestrator, Scavenger, Scheduler, Worker, WorkerAssistant, Labourer, Essential, TaskManager, EcologyManager, MetaHandler — each with a targeted hint (Step Functions / EventBridge / durable functions / plain `sosw.app.Processor`). `.. deprecated:: 3.0.0` directives added to every class docstring.
- **`sosw/__init__.py` → PEP 562 lazy façade**: `import sosw` no longer imports boto3 or any orchestration module (subprocess-verified under `warnings.simplefilter('error')`); every previously-exported name still importable; `__version__` served via `importlib.metadata` with a `'3.0.0'` fallback.
- **`siblings.py`** now imports `Processor` from `sosw.app` directly — internal component use stays warning-free.

## Verification
- Suite: **287 passed, 2 skipped** (267 baseline + 20 new deprecation tests). The 11 pytest-summary warnings are the intended once-per-entity DeprecationWarnings from existing tests instantiating deprecated classes.
- New modules at 100% coverage; façade purity subprocess test in CI.

## Notes
- `examples/` still imports through the façade (works; modernized in the docs stream).
- The linked migration guide page ships in the docs rebuild (R9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)