### PR TITLE
3.0.0: LambdaApi generic API Gateway component (work stream 3)

### DIFF
--- a/sosw/__init__.py
+++ b/sosw/__init__.py
@@ -37,6 +37,7 @@ in ``sosw`` 4.0. See the migration guide: https://docs.sosw.app/migration_3_0.ht
 __all__ = [
     'Processor',
     'LambdaGlobals',
+    'LambdaApi',
     'get_lambda_handler',
     'Essential',
     'Labourer',
@@ -54,6 +55,7 @@ from importlib import import_module
 _LAZY_ATTRIBUTES = {
     'Processor':          'sosw.app',
     'LambdaGlobals':      'sosw.app',
+    'LambdaApi':          'sosw.lambda_api',
     'get_lambda_handler': 'sosw.app',
     'Essential':          'sosw.essential',
     'Labourer':           'sosw.labourer',

--- a/sosw/components/exceptions.py
+++ b/sosw/components/exceptions.py
@@ -1,2 +1,82 @@
 class EventNotFromSourceException(ValueError):
     pass
+
+
+class ApiError(Exception):
+    """
+    Base class for exceptions that map to an HTTP response of :py:class:`sosw.lambda_api.LambdaApi`.
+
+    Handlers raise these (or subclasses); ``LambdaApi`` renders them as a JSON error envelope:
+    ``{'error': {'code': error_code, 'message': message}}`` with the appropriate HTTP status code.
+
+    Subclasses override the class attributes; per-instance overrides are supported through
+    the constructor keyword arguments.
+
+    :param str message:     Human readable error description. Defaults to ``default_message``.
+    :param int status_code: Optional per-instance override of the HTTP status code.
+    :param str error_code:  Optional per-instance override of the machine-readable error code.
+    """
+
+    status_code = 500
+    error_code = 'SERVER_ERROR'
+    default_message = 'Internal server error'
+
+
+    def __init__(self, message: str = None, status_code: int = None, error_code: str = None):
+        self.message = message if message is not None else self.default_message
+
+        if status_code is not None:
+            self.status_code = status_code
+
+        if error_code is not None:
+            self.error_code = error_code
+
+        super().__init__(self.message)
+
+
+class BadRequestError(ApiError):
+    """The request is malformed or fails validation. Maps to HTTP 400."""
+
+    status_code = 400
+    error_code = 'BAD_REQUEST'
+    default_message = 'Bad request'
+
+
+class UnauthorizedError(ApiError):
+    """The caller identity cannot be established (missing/expired credentials). Maps to HTTP 401."""
+
+    status_code = 401
+    error_code = 'UNAUTHORIZED'
+    default_message = 'Unauthorized'
+
+
+class ForbiddenError(ApiError):
+    """The caller is authenticated, but not allowed to perform the action. Maps to HTTP 403."""
+
+    status_code = 403
+    error_code = 'FORBIDDEN'
+    default_message = 'Forbidden'
+
+
+class NotFoundError(ApiError):
+    """The requested resource or route does not exist. Maps to HTTP 404."""
+
+    status_code = 404
+    error_code = 'NOT_FOUND'
+    default_message = 'Not found'
+
+
+class ConflictError(ApiError):
+    """The request conflicts with the current state of the resource. Maps to HTTP 409."""
+
+    status_code = 409
+    error_code = 'CONFLICT'
+    default_message = 'Conflict'
+
+
+class ServerError(ApiError):
+    """Unexpected server-side failure. Maps to HTTP 500."""
+
+    status_code = 500
+    error_code = 'SERVER_ERROR'
+    default_message = 'Internal server error'

--- a/sosw/lambda_api.py
+++ b/sosw/lambda_api.py
@@ -372,7 +372,9 @@ class LambdaApi(Processor):
         :return:            The claims dictionary, or an empty dict if the event carries none.
         """
 
-        authorizer = (event.get('requestContext') or {}).get('authorizer') or {}
+        authorizer = (event.get('requestContext') or {}).get('authorizer')
+        if not isinstance(authorizer, dict):
+            authorizer = {}
 
         claims = authorizer.get('claims')
         if not isinstance(claims, dict):

--- a/sosw/lambda_api.py
+++ b/sosw/lambda_api.py
@@ -1,0 +1,634 @@
+"""
+..  hidden-code-block:: text
+    :label: View Licence Agreement <br>
+
+    sosw - Serverless Orchestrator of Serverless Workers
+
+    The MIT License (MIT)
+    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+"""
+
+__all__ = ['LambdaApi']
+__author__ = "Nikolay Grishchenko"
+
+try:
+    from aws_lambda_powertools import Logger
+
+    logger = Logger(child=True)
+
+except ImportError:
+    import logging
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+import json
+import re
+import time
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+from urllib.parse import unquote
+
+from sosw.app import Processor
+from sosw.components.exceptions import ApiError, BadRequestError, ForbiddenError, NotFoundError, ServerError, \
+    UnauthorizedError
+
+
+class LambdaApi(Processor):
+    """
+    Base Processor for AWS Lambda functions behind API Gateway. Supports both the REST API (payload
+    version 1.0) and the HTTP API (payload version 2.0) proxy event shapes.
+
+    Provides a declarative router configured with the ``routes`` config parameter, Cognito JWT claims
+    extraction and validation, config-driven CORS headers, JSON response rendering with a
+    DynamoDB-friendly encoder, and a uniform machine-readable error envelope.
+
+    Subclasses implement the handler methods and declare them in ``routes``:
+
+    ..  code-block:: python
+
+        from sosw.app import LambdaGlobals, get_lambda_handler
+        from sosw.lambda_api import LambdaApi
+
+        class Processor(LambdaApi):
+
+            DEFAULT_CONFIG = {
+                'auth_enabled': True,
+                'routes':       {
+                    'GET /things':            'list_things',
+                    'GET /things/{thing_id}': 'get_thing',
+                },
+            }
+
+            def list_things(self, event, **kwargs):
+                return {'things': self.get_ddbc('things').scan()}
+
+            def get_thing(self, event, thing_id=None, **kwargs):
+                return {'thing': self.get_ddbc('things').get_by_query({'thing_id': thing_id})}
+
+        global_vars = LambdaGlobals()
+        lambda_handler = get_lambda_handler(Processor, global_vars)
+
+    Handlers receive the raw event as the first positional argument and the path parameters extracted
+    from the request path (per the ``{param}`` placeholders of the matched route) as keyword arguments.
+    A handler may return:
+
+    * any JSON-serializable object - rendered as a ``200`` response body;
+    * a pre-rendered response dict containing ``statusCode`` (e.g. built with :meth:`make_response`
+      using a custom status code or extra headers) - passed through to API Gateway untouched;
+    * or raise :py:class:`sosw.components.exceptions.ApiError` (or a subclass) - rendered as the
+      corresponding HTTP error envelope.
+
+    ..  note::
+
+        Unlike regular ``sosw`` Processors which are required to fail fast and loud, ``__call__``
+        of this class intentionally converts exceptions to well-formed HTTP error responses:
+        an API Gateway integration must always return a valid response to the client. This is the
+        API contract layer, not silent error handling: every exception is logged server-side
+        (unexpected ones with the full traceback), counted in ``self.stats``, and unexpected
+        exceptions are never exposed to the client beyond a generic ``500`` envelope.
+
+    Configuration parameters of this class:
+
+    * ``routes`` - dict mapping ``'METHOD /path'`` route keys to names of handler methods.
+      Paths support API Gateway resource syntax placeholders: ``{param}`` and greedy ``{proxy+}``.
+    * ``auth_enabled`` - when ``True`` (secure default), requests must carry Cognito claims
+      injected by the API Gateway authorizer, otherwise ``401`` is returned.
+    * ``authorized_groups`` - optional list of Cognito group names. When non-empty, the caller
+      must be a member of at least one of them (the ``cognito:groups`` claim), otherwise ``403``.
+    * ``cors_headers`` - dict of headers attached to every rendered response.
+    * ``path_prefixes`` - optional list of prefixes (e.g. stage or mount prefixes) stripped from
+      the request path before route matching.
+    """
+
+    DEFAULT_CONFIG = {
+        'auth_enabled':      True,
+        'authorized_groups': [],
+        'routes':            {},
+        'path_prefixes':     [],
+        'cors_headers':      {
+            'Access-Control-Allow-Origin':  '*',
+            'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With, Accept, Origin',
+            'Content-Type':                 'application/json',
+        },
+    }
+
+    # Claims of the caller of the request currently being processed. Reset at the beginning of every
+    # invocation, populated after successful authorization (or best-effort when `auth_enabled` is off).
+    claims: dict = None
+
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the Processor and the container-lifetime router cache.
+
+        The compiled router is intentionally an instance-level cache: warm Lambda containers reuse
+        the Processor instance across invocations (see :py:class:`sosw.app.LambdaGlobals`), so the
+        routes are parsed and their patterns compiled only once per container.
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self._router = None
+        self.claims = {}
+
+
+    def __call__(self, event: dict, *args, **kwargs) -> dict:
+        """
+        Dispatch an API Gateway proxy event to the configured route handler and render the response.
+
+        The processing pipeline: parse the event (v1/v2) -> authorize the caller -> match the route ->
+        run the :meth:`check_route_access` hook -> call the handler -> render the result.
+
+        Any :py:class:`sosw.components.exceptions.ApiError` raised during the pipeline (including
+        from handlers) is rendered as its HTTP error envelope. Any unexpected exception is logged
+        with the full traceback and rendered as a generic ``500`` envelope without leaking internals.
+
+        :param dict event:  API Gateway proxy event (REST v1 or HTTP v2).
+        :rtype:             dict
+        :return:            API Gateway proxy response: ``{'statusCode', 'headers', 'body'}``.
+        """
+
+        super().__call__(event, *args, **kwargs)
+
+        self.stats['api_calls'] += 1
+        self.claims = {}
+
+        try:
+            method, path = self.parse_event(event)
+
+            if self._c('auth_enabled', True):
+                self.claims = self.validate_authorization(event)
+            else:
+                self.claims = self.get_claims(event)
+
+            route, path_params = self.match_route(method, path)
+            self.stats[self.route_stats_key(route['route'])] += 1
+
+            self.check_route_access(route['route'], self.claims)
+
+            result = route['handler'](event, **path_params)
+
+            if isinstance(result, dict) and 'statusCode' in result:
+                return result
+
+            return self.make_response(result)
+
+        except ApiError as err:
+            logger.warning("API request failed with %s (HTTP %s): %s",
+                           err.__class__.__name__, err.status_code, err)
+            return self.make_error_response(err)
+
+        except Exception:
+            logger.exception("Unexpected exception while processing the API request")
+            return self.make_error_response(ServerError())
+
+
+    def parse_event(self, event: dict) -> tuple:
+        """
+        Extract the HTTP method and the normalized request path from an API Gateway proxy event.
+
+        Supported event shapes:
+
+        * REST API v1: ``httpMethod`` + ``path``;
+        * HTTP API v2: ``requestContext.http.method`` + ``rawPath``;
+        * trimmed v2 events carrying only ``routeKey`` (``'GET /things'``) as the last resort.
+
+        The path is normalized (query string and trailing slash removed) and the first matching
+        entry of the ``path_prefixes`` config parameter is stripped from it.
+
+        :param dict event:          Raw Lambda event.
+        :rtype:                     tuple
+        :return:                    Tuple of (method, path), method upper-cased.
+        :raises BadRequestError:    If the event does not look like an API Gateway proxy event.
+        """
+
+        method = event.get('httpMethod')
+        path = event.get('path')
+
+        if not method:
+            http = (event.get('requestContext') or {}).get('http') or {}
+            method = http.get('method')
+            path = event.get('rawPath') or http.get('path')
+
+        if not method and ' ' in str(event.get('routeKey') or ''):
+            method, _, path = event['routeKey'].partition(' ')
+
+        if not method or not path:
+            raise BadRequestError("Unable to determine HTTP method and path from the event")
+
+        return method.upper(), self.strip_path_prefix(self._normalize_path(path))
+
+
+    def get_router(self) -> list:
+        """
+        Return the compiled router, building it on the first request of the container.
+
+        The router is built from the ``routes`` config parameter by :meth:`build_router` and cached
+        on the instance for the container lifetime, so warm invocations skip parsing and regex
+        compilation entirely.
+
+        :rtype:     list
+        :return:    List of compiled route entries.
+        """
+
+        if self._router is None:
+            self._router = self.build_router()
+
+        return self._router
+
+
+    def build_router(self) -> list:
+        """
+        Compile the ``routes`` config parameter into a list of route entries.
+
+        Each ``'METHOD /path': 'handler_name'`` config pair becomes a dict with the original route
+        key, the upper-cased method, the normalized path template, the compiled path pattern and
+        the bound handler method. Routes without path parameters are ordered before parametrized
+        ones, so ``GET /things/count`` wins over ``GET /things/{thing_id}`` regardless of the
+        declaration order. Within each group the config declaration order is preserved.
+
+        :rtype:             list
+        :return:            List of compiled route entries.
+        :raises ValueError: If a route key is malformed or a handler method is missing.
+        """
+
+        router = []
+
+        for route_key, handler_name in (self._c('routes') or {}).items():
+            method, _, path_template = str(route_key).strip().partition(' ')
+            path_template = path_template.strip()
+
+            if not method or not path_template:
+                raise ValueError(f"Invalid route {route_key!r}. Expected format: 'METHOD /path'")
+
+            handler = getattr(self, handler_name, None) if isinstance(handler_name, str) else None
+            if not callable(handler):
+                raise ValueError(f"Route {route_key!r} points to {handler_name!r} which is not "
+                                 f"a method of {self.__class__.__name__}")
+
+            path_template = self._normalize_path(path_template)
+
+            router.append({
+                'route':   str(route_key),
+                'method':  method.upper(),
+                'path':    path_template,
+                'pattern': self.compile_path_pattern(path_template),
+                'handler': handler,
+            })
+
+        router.sort(key=lambda entry: '{' in entry['path'])
+
+        return router
+
+
+    @staticmethod
+    def compile_path_pattern(path_template: str) -> re.Pattern:
+        """
+        Compile a path template with API Gateway resource syntax into a regex pattern.
+
+        ``{param}`` placeholders match a single path segment as the named group ``param``.
+        The greedy ``{proxy+}`` form matches the rest of the path (including slashes) as ``proxy``.
+
+        :param str path_template:   Path template, e.g. ``'/things/{thing_id}'``.
+        :rtype:                     re.Pattern
+        :return:                    Compiled pattern matching the whole request path.
+        """
+
+        pattern = ''
+
+        for token in re.split(r'({[^{}]+})', path_template):
+            if token.startswith('{') and token.endswith('}'):
+                name = token[1:-1]
+                if name.endswith('+'):
+                    pattern += f'(?P<{name[:-1]}>.+)'
+                else:
+                    pattern += f'(?P<{name}>[^/]+)'
+            else:
+                pattern += re.escape(token)
+
+        return re.compile(f'^{pattern}$')
+
+
+    def match_route(self, method: str, path: str) -> tuple:
+        """
+        Find the route entry matching the request and extract its path parameters.
+
+        Path parameter values are URL-decoded. Requests that match no configured route (either by
+        path or by method) raise :py:class:`sosw.components.exceptions.NotFoundError` -> ``404``.
+
+        :param str method:      Upper-cased HTTP method of the request.
+        :param str path:        Normalized request path.
+        :rtype:                 tuple
+        :return:                Tuple of (route entry, dict of extracted path parameters).
+        :raises NotFoundError:  When no configured route matches the request.
+        """
+
+        for route in self.get_router():
+            if route['method'] != method:
+                continue
+
+            match = route['pattern'].match(path)
+            if match:
+                return route, {name: unquote(value) for name, value in match.groupdict().items()}
+
+        raise NotFoundError(f"No route configured for: {method} {path}")
+
+
+    @staticmethod
+    def get_claims(event: dict) -> dict:
+        """
+        Extract Cognito JWT claims from either API Gateway authorizer event shape.
+
+        * REST API v1 (Cognito User Pool authorizer): ``requestContext.authorizer.claims``
+        * HTTP API v2 (JWT authorizer): ``requestContext.authorizer.jwt.claims``
+
+        Both the id and access token claim sets are supported - the method does not require any
+        specific claim to be present.
+
+        :param dict event:  API Gateway proxy event.
+        :rtype:             dict
+        :return:            The claims dictionary, or an empty dict if the event carries none.
+        """
+
+        authorizer = (event.get('requestContext') or {}).get('authorizer') or {}
+
+        claims = authorizer.get('claims')
+        if not isinstance(claims, dict):
+            jwt_data = authorizer.get('jwt')
+            claims = jwt_data.get('claims') if isinstance(jwt_data, dict) else None
+
+        return claims if isinstance(claims, dict) else {}
+
+
+    def validate_authorization(self, event: dict) -> dict:
+        """
+        Validate the caller identity from the claims injected by the API Gateway authorizer.
+
+        The authorizer has already verified the JWT signature; this method enforces that claims are
+        present, the token is not expired, and (when the ``authorized_groups`` config parameter is
+        non-empty) the caller belongs to at least one authorized Cognito group.
+
+        Error responses never include claim contents; the reasons are logged server-side only.
+
+        :param dict event:              API Gateway proxy event.
+        :rtype:                         dict
+        :return:                        The validated claims.
+        :raises UnauthorizedError:      When claims are missing or the token is expired -> ``401``.
+        :raises ForbiddenError:         When the caller is not in any authorized group -> ``403``.
+        """
+
+        claims = self.get_claims(event)
+
+        if not claims:
+            logger.warning("No authorization claims found in the event")
+            raise UnauthorizedError()
+
+        if self.token_expired(claims.get('exp')):
+            logger.warning("Authorization token of the caller has expired")
+            raise UnauthorizedError()
+
+        authorized_groups = self._c('authorized_groups') or []
+        if authorized_groups:
+            caller_groups = self.parse_groups(claims.get('cognito:groups'))
+            if not set(map(str, authorized_groups)) & set(caller_groups):
+                logger.warning("Caller is not a member of any of the authorized Cognito groups")
+                raise ForbiddenError()
+
+        return claims
+
+
+    @staticmethod
+    def token_expired(exp: Any) -> bool:
+        """
+        Check whether the ``exp`` claim points to the past.
+
+        Tolerated formats: numeric epoch (the standard JWT claim), numeric strings (the form
+        HTTP API v2 authorizers deliver), and the legacy custom-authorizer string format
+        ``'Wed Aug 06 09:02:12 UTC 2025'``. A missing or unparsable claim is not treated as
+        expired - the API Gateway authorizer remains the authority on token validity.
+
+        :param exp: Value of the ``exp`` claim in any supported format.
+        :rtype:     bool
+        """
+
+        if exp is None:
+            return False
+
+        if isinstance(exp, (int, float, Decimal)):
+            return float(exp) < time.time()
+
+        if isinstance(exp, str):
+            value = exp.strip()
+
+            if re.fullmatch(r'\d+(\.\d+)?', value):
+                return float(value) < time.time()
+
+            try:
+                parsed = datetime.strptime(value, '%a %b %d %H:%M:%S UTC %Y')
+            except ValueError:
+                logger.warning("Unsupported string format of the 'exp' claim. Skipping the expiration check.")
+                return False
+
+            return parsed.replace(tzinfo=timezone.utc).timestamp() < time.time()
+
+        logger.warning("Unsupported type of the 'exp' claim: %s. Skipping the expiration check.",
+                       type(exp).__name__)
+        return False
+
+
+    @staticmethod
+    def parse_groups(raw_groups: Any) -> list:
+        """
+        Parse the ``cognito:groups`` claim into a list of group names.
+
+        Tolerated formats: a real list (REST API v1), the stringified ``'[admins users]'`` form
+        delivered by HTTP API v2 JWT authorizers, and comma- or space-separated plain strings.
+
+        :param raw_groups:  Raw value of the ``cognito:groups`` claim.
+        :rtype:             list
+        """
+
+        if not raw_groups:
+            return []
+
+        if isinstance(raw_groups, (list, tuple, set)):
+            return [str(group).strip() for group in raw_groups if str(group).strip()]
+
+        if isinstance(raw_groups, str):
+            return [group for group in re.split(r'[,\s]+', raw_groups.strip('[] ')) if group]
+
+        return [str(raw_groups)]
+
+
+    def check_route_access(self, route: str, claims: dict) -> None:
+        """
+        Per-route access control hook, called after route matching and before the handler.
+
+        The base implementation allows everything. Override in subclasses to implement custom RBAC
+        (e.g. permission tables in DynamoDB, interface grants, organization scopes) and raise
+        :py:class:`sosw.components.exceptions.ForbiddenError` (-> ``403``) or
+        :py:class:`sosw.components.exceptions.UnauthorizedError` (-> ``401``) to deny the request.
+
+        :param str route:   The matched route key exactly as declared in the ``routes`` config,
+                            e.g. ``'GET /things/{thing_id}'``.
+        :param dict claims: Validated claims of the caller (empty dict when ``auth_enabled`` is off
+                            and the event carries no claims).
+        """
+
+        logger.debug("Default check_route_access() allows route: %s", route)
+
+
+    def make_response(self, body: Any = None, status_code: int = 200, headers: dict = None) -> dict:
+        """
+        Render an API Gateway proxy response with the configured CORS headers.
+
+        The body is JSON-serialized with :meth:`json_default`, which supports the types DynamoDB
+        and datetime-heavy code commonly return (``Decimal``, ``datetime``, ``date``, ``set``).
+
+        :param body:            JSON-serializable payload, or ``None`` for an empty body.
+        :param int status_code: HTTP status code of the response.
+        :param dict headers:    Extra headers merged over the configured ``cors_headers``.
+        :rtype:                 dict
+        :return:                API Gateway proxy response: ``{'statusCode', 'headers', 'body'}``.
+        """
+
+        response_headers = dict(self._c('cors_headers') or {})
+        response_headers.update(headers or {})
+
+        return {
+            'statusCode': status_code,
+            'headers':    response_headers,
+            'body':       '' if body is None else json.dumps(body, default=self.json_default),
+        }
+
+
+    def make_error_response(self, error: ApiError) -> dict:
+        """
+        Render the uniform error envelope for an ApiError and count the error statistics.
+
+        The envelope is ``{'error': {'code': <MACHINE_CODE>, 'message': <human readable>}}``.
+        Statistics: ``api_errors_4xx`` / ``api_errors_5xx`` per status code family.
+
+        :param ApiError error:  The error to render.
+        :rtype:                 dict
+        :return:                API Gateway proxy response with the error envelope.
+        """
+
+        self.stats[f'api_errors_{error.status_code // 100}xx'] += 1
+
+        body = {
+            'error': {
+                'code':    error.error_code,
+                'message': str(error),
+            },
+        }
+
+        return self.make_response(body, status_code=error.status_code)
+
+
+    @staticmethod
+    def json_default(value: Any) -> Any:
+        """
+        JSON encoder fallback for types that ``json.dumps`` does not handle natively.
+
+        * ``Decimal`` (as returned by DynamoDB) - ``int`` when integral, else ``float``;
+        * ``datetime`` / ``date`` - ISO-8601 string;
+        * ``set`` / ``frozenset`` - sorted list (plain list when elements are not sortable).
+
+        Override in subclasses to support more types (e.g. ``UUID``).
+
+        :param value:       Value that JSON could not serialize.
+        :return:            A JSON-serializable representation.
+        :raises TypeError:  For unsupported types (standard ``json`` contract).
+        """
+
+        if isinstance(value, Decimal):
+            return int(value) if value == value.to_integral_value() else float(value)
+
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+
+        if isinstance(value, (set, frozenset)):
+            try:
+                return sorted(value)
+            except TypeError:
+                return list(value)
+
+        raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+    def strip_path_prefix(self, path: str) -> str:
+        """
+        Strip the first matching entry of the ``path_prefixes`` config parameter from the path.
+
+        Useful when the deployed API serves routes under a stage or mount prefix
+        (e.g. ``/prod/things`` -> ``/things`` with ``'path_prefixes': ['/prod']``).
+
+        :param str path:    Normalized request path.
+        :rtype:             str
+        """
+
+        for prefix in self._c('path_prefixes') or []:
+            prefix = self._normalize_path(prefix)
+
+            if prefix != '/' and (path == prefix or path.startswith(prefix + '/')):
+                stripped = path[len(prefix):]
+                return stripped if stripped.startswith('/') else f'/{stripped}'
+
+        return path
+
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """
+        Normalize a path: strip the query string and the trailing slash, ensure a leading slash.
+
+        :param str path:    Raw path.
+        :rtype:             str
+        """
+
+        path = str(path or '').split('?', 1)[0].strip()
+
+        if not path.startswith('/'):
+            path = f'/{path}'
+
+        if len(path) > 1:
+            path = path.rstrip('/') or '/'
+
+        return path
+
+
+    @staticmethod
+    def route_stats_key(route: str) -> str:
+        """
+        Build the snake_case ``self.stats`` counter name for a route key.
+
+        E.g. ``'GET /things/{thing_id}'`` -> ``'api_route_get_things_thing_id'``.
+
+        :param str route:   Route key as declared in the ``routes`` config.
+        :rtype:             str
+        """
+
+        return 'api_route_' + re.sub(r'[^a-zA-Z0-9]+', '_', str(route)).strip('_').lower()

--- a/sosw/test/suite_unit.py
+++ b/sosw/test/suite_unit.py
@@ -2,6 +2,7 @@
 from .unit.test_app import app_UnitTestCase
 from .unit.test_deprecations import Deprecations_UnitTestCase
 from .unit.test_labourer import Labourer_UnitTestCase
+from .unit.test_lambda_api import lambda_api_UnitTestCase
 from .unit.test_orchestrator import Orchestrator_UnitTestCase
 from .unit.test_scavenger import Scavenger_UnitTestCase
 from .unit.test_scheduler import Scheduler_UnitTestCase
@@ -28,6 +29,7 @@ def suite():
     test_suite.addTest(unittest.makeSuite(app_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Deprecations_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Labourer_UnitTestCase))
+    test_suite.addTest(unittest.makeSuite(lambda_api_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Orchestrator_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Scavenger_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Scheduler_UnitTestCase))

--- a/sosw/test/unit/test_lambda_api.py
+++ b/sosw/test/unit/test_lambda_api.py
@@ -1,0 +1,651 @@
+import importlib
+import json
+import os
+import sys
+import time
+import unittest
+
+from copy import deepcopy
+from datetime import date, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+os.environ["STAGE"] = "test"
+os.environ["autotest"] = "True"
+
+from sosw.app import LambdaGlobals, get_lambda_handler
+from sosw.components.exceptions import ApiError, BadRequestError, ConflictError, ForbiddenError, NotFoundError, \
+    ServerError, UnauthorizedError
+from sosw.lambda_api import LambdaApi
+
+
+class lambda_api_UnitTestCase(unittest.TestCase):
+    TEST_CONFIG = {
+        'auth_enabled': False,
+        'routes':       {
+            'GET /things/{thing_id}': 'get_thing',  # Declared before the static routes on purpose.
+            'GET /things':            'list_things',
+            'GET /things/count':      'count_things',
+            'POST /things':           'create_thing',
+            'GET /files/{proxy+}':    'get_file',
+            'GET /types':             'get_types',
+            'GET /boom':              'boom',
+            'GET /error':             'raise_configured_error',
+        },
+    }
+
+    AUTH_CONFIG = {
+        'auth_enabled': True,
+        'routes':       {'GET /things': 'list_things'},
+    }
+
+    GROUPS_CONFIG = {
+        'auth_enabled':      True,
+        'authorized_groups': ['admins'],
+        'routes':            {'GET /things': 'list_things'},
+    }
+
+
+    class ThingsApi(LambdaApi):
+
+        error_to_raise = None
+
+
+        def list_things(self, event, **kwargs):
+            return {'things': ['red', 'green']}
+
+
+        def count_things(self, event, **kwargs):
+            return {'count': 2}
+
+
+        def get_thing(self, event, thing_id=None, **kwargs):
+            return {'thing_id': thing_id}
+
+
+        def create_thing(self, event, **kwargs):
+            return self.make_response({'created': True}, status_code=201, headers={'x-total-count': '1'})
+
+
+        def get_file(self, event, proxy=None, **kwargs):
+            return {'proxy': proxy}
+
+
+        def get_types(self, event, **kwargs):
+            return {
+                'price':      Decimal('9.99'),
+                'quantity':   Decimal('3'),
+                'created_at': datetime(2026, 7, 4, 12, 30, 0),
+                'tags':       {'beta', 'alpha'},
+            }
+
+
+        def boom(self, event, **kwargs):
+            raise RuntimeError("Database password is hunter2")
+
+
+        def raise_configured_error(self, event, **kwargs):
+            raise self.error_to_raise
+
+
+    def setUp(self):
+        self.patcher = patch.object(LambdaApi, 'get_config', MagicMock(return_value={}))
+        self.get_config_patch = self.patcher.start()
+
+
+    def tearDown(self):
+        self.patcher.stop()
+
+        # Reset the container-level globals of sosw.app that get_lambda_handler tests may have populated.
+        reset_globals = LambdaGlobals()
+        reset_globals.processor = None
+
+
+    def make_processor(self, custom_config=None):
+        config = deepcopy(custom_config if custom_config is not None else self.TEST_CONFIG)
+        return self.ThingsApi(custom_config=config)
+
+
+    @staticmethod
+    def make_v1_event(method='GET', path='/things', claims=None):
+        """Trimmed API Gateway REST API (payload version 1.0) proxy event."""
+
+        event = {
+            'resource':              path,
+            'path':                  path,
+            'httpMethod':            method,
+            'headers':               {'Accept': 'application/json', 'Host': 'api.example.com'},
+            'queryStringParameters': None,
+            'pathParameters':        None,
+            'requestContext':        {
+                'resourcePath': path,
+                'httpMethod':   method,
+                'stage':        'prod',
+                'identity':     {'sourceIp': '192.0.2.10'},
+            },
+            'body':                  None,
+            'isBase64Encoded':       False,
+        }
+        if claims is not None:
+            event['requestContext']['authorizer'] = {'claims': claims}
+        return event
+
+
+    @staticmethod
+    def make_v2_event(method='GET', path='/things', claims=None):
+        """Trimmed API Gateway HTTP API (payload version 2.0) proxy event."""
+
+        event = {
+            'version':         '2.0',
+            'routeKey':        f'{method} {path}',
+            'rawPath':         path,
+            'rawQueryString':  '',
+            'headers':         {'accept': 'application/json', 'host': 'api.example.com'},
+            'requestContext':  {
+                'accountId': '123456789012',
+                'apiId':     'a1b2c3d4e5',
+                'stage':     '$default',
+                'http':      {
+                    'method':    method,
+                    'path':      path,
+                    'protocol':  'HTTP/1.1',
+                    'sourceIp':  '192.0.2.10',
+                    'userAgent': 'pytest',
+                },
+            },
+            'body':            None,
+            'isBase64Encoded': False,
+        }
+        if claims is not None:
+            event['requestContext']['authorizer'] = {'jwt': {'claims': claims, 'scopes': None}}
+        return event
+
+
+    @staticmethod
+    def make_claims(**overrides):
+        """Claims of a Cognito id token, in the shape the API Gateway authorizer delivers them."""
+
+        claims = {
+            'sub':              '5f95d472-1234-5678-9abc-def012345678',
+            'aud':              '6q1c4ff87a1p3l6nkl2vd0e2e8',
+            'token_use':        'id',
+            'cognito:username': 'jane',
+            'email':            'jane@example.com',
+            'exp':              int(time.time()) + 3600,
+            'iat':              int(time.time()) - 60,
+        }
+        claims.update(overrides)
+        return claims
+
+
+    # ------------------------------------------------------------------ routing
+
+    def test_call__routes_to_handler__v1(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {'things': ['red', 'green']})
+
+
+    def test_call__unknown_route__404(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/nope'))
+
+        self.assertEqual(response['statusCode'], 404)
+        body = json.loads(response['body'])
+        self.assertEqual(body['error']['code'], 'NOT_FOUND')
+        self.assertIn('GET /nope', body['error']['message'])
+
+
+    def test_call__wrong_method__404(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(method='DELETE', path='/things'))
+
+        self.assertEqual(response['statusCode'], 404)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'NOT_FOUND')
+
+
+    def test_call__static_route_wins_over_parametrized(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/things/count'))
+
+        self.assertEqual(json.loads(response['body']), {'count': 2})
+
+
+    def test_call__trailing_slash_and_query_string_normalized(self):
+        processor = self.make_processor()
+
+        event = self.make_v1_event(path='/things/')
+        event['queryStringParameters'] = {'color': 'red'}
+        self.assertEqual(processor(event)['statusCode'], 200)
+
+        # Defensive: some proxies keep the query string glued to the path.
+        response = processor(self.make_v1_event(path='/things?color=red'))
+        self.assertEqual(response['statusCode'], 200)
+
+
+    def test_call__path_prefix_stripped(self):
+        config = deepcopy(self.TEST_CONFIG)
+        config['path_prefixes'] = ['/api']
+        processor = self.make_processor(config)
+
+        response = processor(self.make_v1_event(path='/api/things'))
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {'things': ['red', 'green']})
+
+
+    def test_get_router__built_once_per_container(self):
+        processor = self.make_processor()
+
+        with patch.object(processor, 'build_router', wraps=processor.build_router) as build_spy:
+            processor(self.make_v1_event(path='/things'))
+            processor(self.make_v1_event(path='/things/42'))
+
+        self.assertEqual(build_spy.call_count, 1)
+
+
+    def test_build_router__invalid_configurations_raise(self):
+        processor = self.make_processor({'auth_enabled': False, 'routes': {'GET /nope': 'no_such_method'}})
+        self.assertRaises(ValueError, processor.build_router)
+
+        # A misconfigured router must surface as a logged 500, never as a broken integration response.
+        response = processor(self.make_v1_event(path='/nope'))
+        self.assertEqual(response['statusCode'], 500)
+
+        processor = self.make_processor({'auth_enabled': False, 'routes': {'GETthings': 'list_things'}})
+        self.assertRaises(ValueError, processor.build_router)
+
+
+    # ------------------------------------------------------------------ event shapes
+
+    def test_call__v2_event__routes_to_handler(self):
+        processor = self.make_processor()
+        response = processor(self.make_v2_event(path='/things'))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {'things': ['red', 'green']})
+
+
+    def test_call__route_key_only_event(self):
+        processor = self.make_processor()
+        response = processor({'routeKey': 'GET /things', 'requestContext': {}})
+
+        self.assertEqual(response['statusCode'], 200)
+
+
+    def test_call__non_api_event__400(self):
+        processor = self.make_processor()
+        response = processor({'Records': [{'eventSource': 'aws:sqs'}]})
+
+        self.assertEqual(response['statusCode'], 400)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'BAD_REQUEST')
+
+
+    # ------------------------------------------------------------------ path parameters
+
+    def test_call__path_params_passed_to_handler(self):
+        processor = self.make_processor()
+
+        response = processor(self.make_v1_event(path='/things/42'))
+        self.assertEqual(json.loads(response['body']), {'thing_id': '42'})
+
+        # Values are URL-decoded.
+        response = processor(self.make_v2_event(path='/things/hello%20world'))
+        self.assertEqual(json.loads(response['body']), {'thing_id': 'hello world'})
+
+
+    def test_call__greedy_proxy_path_params(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/files/reports/2026/07/data.csv'))
+
+        self.assertEqual(json.loads(response['body']), {'proxy': 'reports/2026/07/data.csv'})
+
+
+    # ------------------------------------------------------------------ authorization
+
+    def test_get_claims__v1_v2_and_missing(self):
+        claims = self.make_claims()
+
+        self.assertEqual(LambdaApi.get_claims(self.make_v1_event(claims=claims)), claims)
+        self.assertEqual(LambdaApi.get_claims(self.make_v2_event(claims=claims)), claims)
+        self.assertEqual(LambdaApi.get_claims(self.make_v1_event()), {})
+        self.assertEqual(LambdaApi.get_claims({}), {})
+
+
+    def test_call__auth_required__missing_claims__401(self):
+        processor = self.make_processor(self.AUTH_CONFIG)
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['statusCode'], 401)
+        body = json.loads(response['body'])
+        self.assertEqual(body['error']['code'], 'UNAUTHORIZED')
+        self.assertEqual(body['error']['message'], 'Unauthorized')
+
+
+    def test_call__auth_required__valid_claims__handler_runs(self):
+        processor = self.make_processor(self.AUTH_CONFIG)
+        claims = self.make_claims()
+        response = processor(self.make_v1_event(path='/things', claims=claims))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(processor.claims, claims)
+
+
+    def test_call__auth_required__v2_claims__handler_runs(self):
+        processor = self.make_processor(self.AUTH_CONFIG)
+        claims = self.make_claims(exp=str(int(time.time()) + 3600))  # v2 authorizers stringify numbers.
+        response = processor(self.make_v2_event(path='/things', claims=claims))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(processor.claims, claims)
+
+
+    def test_call__expired_token__401_without_claim_leak(self):
+        processor = self.make_processor(self.AUTH_CONFIG)
+        claims = self.make_claims(exp=int(time.time()) - 100)
+        response = processor(self.make_v1_event(path='/things', claims=claims))
+
+        self.assertEqual(response['statusCode'], 401)
+        self.assertNotIn(claims['email'], response['body'])
+        self.assertNotIn(claims['sub'], response['body'])
+
+
+    def test_token_expired__format_tolerance(self):
+        now = time.time()
+
+        self.assertTrue(LambdaApi.token_expired(int(now) - 100))
+        self.assertFalse(LambdaApi.token_expired(int(now) + 100))
+        self.assertTrue(LambdaApi.token_expired(now - 100.5))
+        self.assertTrue(LambdaApi.token_expired(str(int(now) - 100)))
+        self.assertFalse(LambdaApi.token_expired(str(int(now) + 100)))
+
+        # Legacy custom-authorizer format.
+        self.assertTrue(LambdaApi.token_expired('Wed Aug 06 09:02:12 UTC 2025'))
+        self.assertFalse(LambdaApi.token_expired('Mon Jan 01 00:00:00 UTC 2125'))
+
+        # Missing or unparsable claims never crash and are not treated as expired.
+        self.assertFalse(LambdaApi.token_expired(None))
+        self.assertFalse(LambdaApi.token_expired('garbage'))
+        self.assertFalse(LambdaApi.token_expired({'weird': 'type'}))
+
+
+    def test_call__wrong_group__403(self):
+        processor = self.make_processor(self.GROUPS_CONFIG)
+
+        claims = self.make_claims(**{'cognito:groups': ['users']})
+        response = processor(self.make_v1_event(path='/things', claims=claims))
+        self.assertEqual(response['statusCode'], 403)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'FORBIDDEN')
+
+        # Missing groups claim is also a 403 when groups are required.
+        response = processor(self.make_v1_event(path='/things', claims=self.make_claims()))
+        self.assertEqual(response['statusCode'], 403)
+
+
+    def test_call__authorized_group__handler_runs(self):
+        processor = self.make_processor(self.GROUPS_CONFIG)
+
+        claims = self.make_claims(**{'cognito:groups': ['admins', 'users']})
+        response = processor(self.make_v1_event(path='/things', claims=claims))
+        self.assertEqual(response['statusCode'], 200)
+
+        # HTTP API v2 delivers the groups claim as a stringified list.
+        claims = self.make_claims(**{'cognito:groups': '[admins users]'})
+        response = processor(self.make_v2_event(path='/things', claims=claims))
+        self.assertEqual(response['statusCode'], 200)
+
+
+    def test_parse_groups__variants(self):
+        self.assertEqual(LambdaApi.parse_groups(None), [])
+        self.assertEqual(LambdaApi.parse_groups([]), [])
+        self.assertEqual(LambdaApi.parse_groups(['admins', 'users']), ['admins', 'users'])
+        self.assertEqual(LambdaApi.parse_groups('admins'), ['admins'])
+        self.assertEqual(LambdaApi.parse_groups('admins,users'), ['admins', 'users'])
+        self.assertEqual(LambdaApi.parse_groups('[admins users]'), ['admins', 'users'])
+        self.assertEqual(LambdaApi.parse_groups(42), ['42'])
+
+
+    def test_call__auth_disabled__no_claims__handler_runs(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(processor.claims, {})
+
+
+    def test_check_route_access__receives_route_and_claims(self):
+        processor = self.make_processor()
+        processor.check_route_access = MagicMock()
+        claims = self.make_claims()
+
+        processor(self.make_v1_event(path='/things/42', claims=claims))
+
+        processor.check_route_access.assert_called_once_with('GET /things/{thing_id}', claims)
+
+
+    def test_check_route_access__override_denies__403(self):
+        class RestrictedApi(self.ThingsApi):
+
+            def check_route_access(self, route, claims):
+                raise ForbiddenError("Route access denied by RBAC")
+
+        processor = RestrictedApi(custom_config=deepcopy(self.TEST_CONFIG))
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['statusCode'], 403)
+        self.assertEqual(json.loads(response['body'])['error']['message'], 'Route access denied by RBAC')
+
+
+    # ------------------------------------------------------------------ responses
+
+    def test_call__default_cors_headers(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['headers']['Access-Control-Allow-Origin'], '*')
+        self.assertEqual(response['headers']['Content-Type'], 'application/json')
+        self.assertIn('GET', response['headers']['Access-Control-Allow-Methods'])
+
+
+    def test_call__custom_cors_headers_from_config(self):
+        config = deepcopy(self.TEST_CONFIG)
+        config['cors_headers'] = {'Access-Control-Allow-Origin': 'https://api.example.com'}
+        processor = self.make_processor(config)
+
+        response = processor(self.make_v1_event(path='/things'))
+
+        self.assertEqual(response['headers']['Access-Control-Allow-Origin'], 'https://api.example.com')
+        # The rest of the default headers survive the recursive config merge.
+        self.assertEqual(response['headers']['Content-Type'], 'application/json')
+
+
+    def test_call__error_responses_carry_cors_headers(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/nope'))
+
+        self.assertEqual(response['statusCode'], 404)
+        self.assertEqual(response['headers']['Access-Control-Allow-Origin'], '*')
+
+
+    def test_json_default__encoder_cases(self):
+        self.assertEqual(LambdaApi.json_default(Decimal('42')), 42)
+        self.assertIsInstance(LambdaApi.json_default(Decimal('42')), int)
+        self.assertEqual(LambdaApi.json_default(Decimal('9.99')), 9.99)
+        self.assertEqual(LambdaApi.json_default(datetime(2026, 7, 4, 12, 30)), '2026-07-04T12:30:00')
+        self.assertEqual(LambdaApi.json_default(date(2026, 7, 4)), '2026-07-04')
+        self.assertEqual(LambdaApi.json_default({3, 1, 2}), [1, 2, 3])
+        self.assertEqual(LambdaApi.json_default(frozenset(['b', 'a'])), ['a', 'b'])
+        self.assertEqual(sorted(LambdaApi.json_default({1, 'mixed'}), key=str), [1, 'mixed'])
+
+        self.assertRaises(TypeError, LambdaApi.json_default, object())
+
+
+    def test_call__body_encodes_dynamodb_types(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(path='/types'))
+
+        body = json.loads(response['body'])
+        self.assertEqual(body['price'], 9.99)
+        self.assertEqual(body['quantity'], 3)
+        self.assertEqual(body['created_at'], '2026-07-04T12:30:00')
+        self.assertEqual(body['tags'], ['alpha', 'beta'])
+
+
+    def test_make_response__none_body_and_extra_headers(self):
+        processor = self.make_processor()
+        response = processor.make_response(None, status_code=204, headers={'x-custom': 'yes'})
+
+        self.assertEqual(response['statusCode'], 204)
+        self.assertEqual(response['body'], '')
+        self.assertEqual(response['headers']['x-custom'], 'yes')
+        self.assertEqual(response['headers']['Access-Control-Allow-Origin'], '*')
+
+
+    def test_call__pre_rendered_response_passthrough(self):
+        processor = self.make_processor()
+        response = processor(self.make_v1_event(method='POST', path='/things'))
+
+        self.assertEqual(response['statusCode'], 201)
+        self.assertEqual(response['headers']['x-total-count'], '1')
+        self.assertEqual(json.loads(response['body']), {'created': True})
+
+
+    # ------------------------------------------------------------------ error mapping
+
+    def test_exceptions__contract(self):
+        expected = [
+            (BadRequestError, 400, 'BAD_REQUEST', 'Bad request'),
+            (UnauthorizedError, 401, 'UNAUTHORIZED', 'Unauthorized'),
+            (ForbiddenError, 403, 'FORBIDDEN', 'Forbidden'),
+            (NotFoundError, 404, 'NOT_FOUND', 'Not found'),
+            (ConflictError, 409, 'CONFLICT', 'Conflict'),
+            (ServerError, 500, 'SERVER_ERROR', 'Internal server error'),
+        ]
+
+        for error_class, status_code, error_code, default_message in expected:
+            error = error_class()
+            self.assertIsInstance(error, ApiError)
+            self.assertEqual(error.status_code, status_code)
+            self.assertEqual(error.error_code, error_code)
+            self.assertEqual(str(error), default_message)
+
+        custom = ApiError("I am a teapot", status_code=418, error_code='TEAPOT')
+        self.assertEqual((custom.status_code, custom.error_code, str(custom)), (418, 'TEAPOT', 'I am a teapot'))
+
+
+    def test_call__api_error_subclasses_map_to_status_and_envelope(self):
+        processor = self.make_processor()
+
+        expected = [
+            (BadRequestError, 400, 'BAD_REQUEST'),
+            (UnauthorizedError, 401, 'UNAUTHORIZED'),
+            (ForbiddenError, 403, 'FORBIDDEN'),
+            (NotFoundError, 404, 'NOT_FOUND'),
+            (ConflictError, 409, 'CONFLICT'),
+            (ServerError, 500, 'SERVER_ERROR'),
+        ]
+
+        for error_class, status_code, error_code in expected:
+            processor.error_to_raise = error_class("Something specific went wrong")
+            response = processor(self.make_v1_event(path='/error'))
+
+            body = json.loads(response['body'])
+            self.assertEqual(response['statusCode'], status_code)
+            self.assertEqual(body['error']['code'], error_code)
+            self.assertEqual(body['error']['message'], 'Something specific went wrong')
+
+
+    def test_call__unexpected_exception__500_without_internals(self):
+        processor = self.make_processor()
+
+        with patch('sosw.lambda_api.logger') as mock_logger:
+            response = processor(self.make_v1_event(path='/boom'))
+
+        self.assertEqual(response['statusCode'], 500)
+        body = json.loads(response['body'])
+        self.assertEqual(body['error']['code'], 'SERVER_ERROR')
+        self.assertEqual(body['error']['message'], 'Internal server error')
+        self.assertNotIn('hunter2', response['body'])
+
+        # The failure must still be fully logged server-side, with the traceback.
+        mock_logger.exception.assert_called_once()
+
+
+    # ------------------------------------------------------------------ stats & warm container
+
+    def test_call__stats_counters(self):
+        processor = self.make_processor()
+
+        processor(self.make_v1_event(path='/things'))
+        processor(self.make_v1_event(path='/things'))
+        processor(self.make_v1_event(path='/nope'))
+        processor(self.make_v1_event(path='/boom'))
+
+        self.assertEqual(processor.stats['api_calls'], 4)
+        self.assertEqual(processor.stats['api_route_get_things'], 2)
+        self.assertEqual(processor.stats['api_route_get_boom'], 1)
+        self.assertEqual(processor.stats['api_errors_4xx'], 1)
+        self.assertEqual(processor.stats['api_errors_5xx'], 1)
+
+
+    def test_call__claims_reset_between_invocations(self):
+        processor = self.make_processor()
+        claims = self.make_claims()
+
+        processor(self.make_v1_event(path='/things', claims=claims))
+        self.assertEqual(processor.claims, claims)
+
+        processor(self.make_v1_event(path='/things'))
+        self.assertEqual(processor.claims, {})
+
+
+    def test_lambda_handler__container_reuse(self):
+        global_vars = LambdaGlobals()
+        lambda_handler = get_lambda_handler(self.ThingsApi, global_vars, custom_config=deepcopy(self.TEST_CONFIG))
+
+        first = lambda_handler(self.make_v1_event(path='/things'), None)
+        processor = global_vars.processor
+        second = lambda_handler(self.make_v1_event(path='/things/42'), None)
+
+        self.assertEqual(first['statusCode'], 200)
+        self.assertEqual(json.loads(second['body']), {'thing_id': '42'})
+
+        # The very same processor instance served both invocations, with the router built once.
+        self.assertIs(global_vars.processor, processor)
+        self.assertIsInstance(global_vars.processor, self.ThingsApi)
+        self.assertIsNotNone(global_vars.processor._router)
+        self.assertEqual(global_vars.processor.stats['total_api_calls'], 2)
+
+
+    # ------------------------------------------------------------------ module plumbing
+
+    def test_normalize_path__variants(self):
+        self.assertEqual(LambdaApi._normalize_path('/things/'), '/things')
+        self.assertEqual(LambdaApi._normalize_path('/things?color=red'), '/things')
+        self.assertEqual(LambdaApi._normalize_path('things'), '/things')
+        self.assertEqual(LambdaApi._normalize_path(''), '/')
+        self.assertEqual(LambdaApi._normalize_path('/'), '/')
+        self.assertEqual(LambdaApi._normalize_path('//'), '/')
+
+
+    def test_logger__powertools_branch(self):
+        """
+        Cover the optional aws_lambda_powertools import branch by injecting a fake package
+        and reloading the module. The module is reloaded back to its real state afterwards.
+        """
+
+        import sosw.lambda_api
+
+        self.addCleanup(importlib.reload, sosw.lambda_api)
+
+        fake_powertools = MagicMock()
+        with patch.dict(sys.modules, {'aws_lambda_powertools': fake_powertools}):
+            reloaded = importlib.reload(sosw.lambda_api)
+
+            fake_powertools.Logger.assert_called_once_with(child=True)
+            self.assertEqual(reloaded.logger, fake_powertools.Logger.return_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sosw/test/unit/test_lambda_api.py
+++ b/sosw/test/unit/test_lambda_api.py
@@ -312,6 +312,10 @@ class lambda_api_UnitTestCase(unittest.TestCase):
         self.assertEqual(LambdaApi.get_claims(self.make_v1_event()), {})
         self.assertEqual(LambdaApi.get_claims({}), {})
 
+        # A crafted non-dict authorizer must degrade to empty claims (401 path), not crash to a 500.
+        self.assertEqual(LambdaApi.get_claims({'requestContext': {'authorizer': 'crafted-string'}}), {})
+        self.assertEqual(LambdaApi.get_claims({'requestContext': {'authorizer': ['crafted', 'list']}}), {})
+
 
     def test_call__auth_required__missing_claims__401(self):
         processor = self.make_processor(self.AUTH_CONFIG)


### PR DESCRIPTION
Part of the **sosw 3.0.0** release. Spec: `.kiro/specs/hq-692-sosw-3-0-0/` (R4, design §4).

## What
New **`sosw.lambda_api.LambdaApi(Processor)`** — a base class for Lambdas behind API Gateway, synthesized from five private implementations used across SOSW projects (none of which had unit tests; this one has 40):

- **Router**: config-declared `'METHOD /path' → handler` with `{param}` and greedy `{proxy+}` segments, URL-decoded params, static-before-parametrized precedence, built once per container.
- **Events**: API Gateway REST (v1), HTTP API (v2), and `routeKey` shapes.
- **Auth**: Cognito claims from both authorizer shapes; tolerant `exp` handling (numeric / digit-string / legacy UTC string); `authorized_groups` gate (list and v2 stringified claims); overridable `check_route_access(route, claims)` for downstream RBAC. Fail-closed: auth runs before routing.
- **Responses**: config-driven CORS, JSON envelope with Decimal/datetime/set encoder, pre-rendered response passthrough.
- **Errors**: new `ApiError` hierarchy in `sosw.components.exceptions` (400/401/403/404/409/500) → `{'error': {'code','message'}}` envelopes; unexpected exceptions log the full traceback server-side and return a generic 500 — leak-probed in tests.
- **Stats**: `api_calls`, per-route counters, `api_errors_4xx/5xx`.

## Verification
- Suite: **307 passed, 2 skipped** (267 baseline + 40 new). New modules at **100% line coverage**.
- Claims-leak assertions, container-reuse (warm start) integration test, powertools import-branch reload test included.

## Semantics notes (vs the private forebears)
- Wrong method on a known path → **404** (not 400); only `ApiError` subclasses map to envelopes (no legacy `ValueError→400`).
- Will be exported from the package façade once #392 (lazy `__init__`) merges — handled at rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)