### PR TITLE
3.0.0: durable execution support + warm-start fixes (work stream 4)

### DIFF
--- a/sosw/app.py
+++ b/sosw/app.py
@@ -52,6 +52,24 @@ from sosw.components.helpers import *
 from sosw.components.dynamo_db import DynamoDbClient
 
 
+def _derive_test_flag(explicit_flag=None):
+    """
+    Resolve the effective ``test`` flag of the Processor or the lambda handler.
+
+    An explicitly provided flag (the ``test`` keyword of the Processor constructor, or the ``test`` key
+    of the Lambda event) always wins. When no flag is provided (``None``), the flag is derived from the
+    ``STAGE`` environment variable: the ``test`` and ``autotest`` stages run in test mode.
+
+    :param explicit_flag:   Explicitly provided value of the flag or None when not provided.
+    :return:                The effective test flag.
+    """
+
+    if explicit_flag is not None:
+        return explicit_flag
+
+    return os.environ.get('STAGE') in ['test', 'autotest']
+
+
 class Processor:
     """
     Core Processor class template. All the main components (Worker, Orchestrator and Scheduler) inherit from this one.
@@ -78,6 +96,10 @@ class Processor:
 
     DEFAULT_CONFIG = {}
 
+    # Set to True in a subclass to skip the lookup of the per-function config in DynamoDB / SSM.
+    # See `init_config()` for details.
+    DISABLE_DDB_CONFIG = False
+
     aws_account: str = None
     aws_region: str = os.getenv('AWS_REGION', None)
     ddb_names: list = None
@@ -91,7 +113,7 @@ class Processor:
         Recursively Updates the default config with parameters from DynamoDB / SSM, then from provided custom config.
         """
 
-        self.test = kwargs.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False
+        self.test = _derive_test_flag(kwargs.get('test'))
 
         if global_vars.lambda_context:
             if invoked_function_arn := getattr(global_vars.lambda_context, 'invoked_function_arn', None):
@@ -114,6 +136,12 @@ class Processor:
         After that, a specific custom config of the Lambda will recursively update the existing one.
         The last step is update config recursively with a passed custom_config.
 
+        The lookup of the specific custom config of the Lambda (``{AWS_LAMBDA_FUNCTION_NAME}_config``
+        from DynamoDB / SSM) can be skipped either by setting the class attribute
+        ``DISABLE_DDB_CONFIG = True`` in your Processor, or by passing a truthy ``disable_ddb_config``
+        key in the ``DEFAULT_CONFIG`` or ``custom_config``. ``DEFAULT_CONFIG`` and ``custom_config``
+        are still applied in this case.
+
         Overwrite this method if custom logic of recursive updates in configs is required.
 
         ..  note:: Read more about :ref:`Config_Sourse`
@@ -121,13 +149,20 @@ class Processor:
         :param Dict custom_config: dict with custom configurations
         """
 
+        custom_config = custom_config or {}
+
         # Initialize config from default config
         self.config = self.DEFAULT_CONFIG or {}
-        # Update config recursively from any existing lambda function config
-        self.config = recursive_update(self.config,
-                                       self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config") or {})
+
+        # Update config recursively from any existing lambda function config, unless explicitly disabled.
+        disable_ddb_config = (self.DISABLE_DDB_CONFIG or self.config.get('disable_ddb_config')
+                              or custom_config.get('disable_ddb_config'))
+        if not disable_ddb_config:
+            self.config = recursive_update(
+                    self.config, self.get_config(f"{os.environ.get('AWS_LAMBDA_FUNCTION_NAME')}_config") or {})
+
         # Update config recursively from custom config
-        self.config = recursive_update(self.config, custom_config or {})
+        self.config = recursive_update(self.config, custom_config)
 
 
     @benchmark
@@ -497,9 +532,13 @@ class LambdaGlobals:
         _processor = val
 
 
-def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
+def _make_lambda_handler(processor_class, global_vars=None, custom_config=None):
     """
-    Return a reference to the entry point of the lambda function.
+    Build the ``lambda_handler`` closure over the given Processor class.
+
+    This is the shared internal builder used by :func:`get_lambda_handler` and by the optional
+    durable functions wrapper (``sosw.durable.get_durable_lambda_handler``). It has no knowledge
+    of any optional SDKs and must stay this way.
 
     :param processor_class:  Callable processor class.
     :param global_vars:      Lambda's global variables (processor, context).
@@ -534,7 +573,7 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
                     __name__, context)
         logger.info(event)
 
-        test = event.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False
+        test = _derive_test_flag(event.get('test') if isinstance(event, dict) else None)
 
         global_vars.lambda_context = context
 
@@ -545,7 +584,6 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
 
         logger.info(global_vars.processor.get_stats())
 
-        global_vars.processor.reset_stats()
         global_vars.processor.reset_stats(recursive=True)
 
         logger.info(result)
@@ -554,6 +592,25 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
 
 
     return lambda_handler
+
+
+def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
+    """
+    Return a reference to the entry point of the lambda function.
+
+    The handler caches the initialized Processor in `global_vars` and reuses it in the warm
+    invocations for the lifetime of the Lambda container. Per-invocation state belongs to
+    ``processor.result`` (reset on every call), while ``processor.stats`` carries the counters
+    of the container lifetime: ``reset_stats()`` runs once after every invocation and preserves
+    the ``total_*`` counters and the ones configured in ``lifetime_stats_params``.
+
+    :param processor_class:  Callable processor class.
+    :param global_vars:      Lambda's global variables (processor, context).
+    :param custom_config:    Custom configuration to pass the processor constructor.
+    :return: Function reference for the lambda handler.
+    """
+
+    return _make_lambda_handler(processor_class, global_vars, custom_config)
 
 
 # Global placeholder for global_vars.

--- a/sosw/durable.py
+++ b/sosw/durable.py
@@ -1,0 +1,163 @@
+"""
+..  hidden-code-block:: text
+    :label: View Licence Agreement <br>
+
+    sosw - Serverless Orchestrator of Serverless Workers
+
+    The MIT License (MIT)
+    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+"""
+
+__all__ = ['get_durable_lambda_handler', 'durable_wait', 'parse_durable_result',
+           'DURABLE_SDK_AVAILABLE', 'durable_step', 'Duration']
+__author__ = "Nikolay Grishchenko"
+
+import json
+import logging
+import time
+
+import sosw.app
+
+from sosw.app import _make_lambda_handler
+
+# Optional AWS Lambda Durable Execution support. The SDK is an optional dependency of sosw:
+# install with `pip install sosw[durable]`. The managed AWS Lambda runtimes also bundle the SDK,
+# but AWS recommends pinning it in production deployment packages. The module itself must import
+# cleanly without the SDK so that the SDK-optional helpers (`durable_wait`, `parse_durable_result`)
+# stay usable in regular Lambdas. Only `get_durable_lambda_handler` genuinely requires the SDK
+# and it fails loudly if the SDK is missing.
+try:
+    from aws_durable_execution_sdk_python import durable_execution, durable_step
+    from aws_durable_execution_sdk_python.config import Duration
+
+    DURABLE_SDK_AVAILABLE = True
+
+except ImportError:
+    durable_execution = durable_step = Duration = None
+
+    DURABLE_SDK_AVAILABLE = False
+
+
+logger = logging.getLogger()
+
+
+def get_durable_lambda_handler(processor_class, global_vars=None, custom_config=None, **durable_kwargs):
+    """
+    Durable twin of :func:`sosw.app.get_lambda_handler`.
+
+    Builds exactly the same warm-start caching ``lambda_handler`` (single Processor instance cached in
+    ``global_vars`` for the lifetime of the Lambda container) and wraps it with the ``durable_execution``
+    decorator of the AWS Lambda Durable Execution SDK. Inside the Processor, ``global_vars.lambda_context``
+    is the ``DurableContext`` of the current invocation: use its ``step()`` / ``wait()`` operations for
+    checkpointed durable operations.
+
+    Requires the optional durable SDK: ``pip install sosw[durable]``. Regular functions should keep
+    using :func:`sosw.app.get_lambda_handler`, which does not even import the SDK.
+
+    :param processor_class:  Callable processor class.
+    :param global_vars:      Lambda's global variables (processor, context).
+    :param custom_config:    Custom configuration to pass the processor constructor.
+    :param durable_kwargs:   Optional keyword arguments to pass through to the ``durable_execution``
+                             decorator of the SDK.
+    :return: Function reference for the lambda handler.
+    """
+
+    if not DURABLE_SDK_AVAILABLE:
+        raise ImportError(
+                "aws-durable-execution-sdk-python is not installed. Run `pip install sosw[durable]` "
+                "(or add aws-durable-execution-sdk-python to your Lambda requirements). "
+                "Non-durable functions should keep using sosw.app.get_lambda_handler.")
+
+    handler = _make_lambda_handler(processor_class, global_vars, custom_config)
+
+    return durable_execution(handler, **durable_kwargs)
+
+
+def durable_wait(seconds: int, global_vars=None):
+    """
+    Wait either using the checkpointed ``wait()`` of the Durable Execution context (when running
+    as a durable function), or falling back to a regular ``time.sleep()`` otherwise.
+
+    This helper lets the very same Processor code run both as a durable and as a regular Lambda.
+    The fallback path does not require the durable SDK to be installed.
+
+    :param int seconds:     Number of seconds to wait.
+    :param global_vars:     Optional instance of ``LambdaGlobals`` holding the ``lambda_context``.
+                            Defaults to the module-level ``sosw.app.global_vars``.
+    """
+
+    gv = global_vars if global_vars is not None else sosw.app.global_vars
+    ctx = getattr(gv, 'lambda_context', None)
+
+    if ctx is not None and hasattr(ctx, 'wait') and Duration is not None:
+        ctx.wait(Duration(seconds=seconds))
+    else:
+        logger.debug("No DurableContext available, falling back to time.sleep(%s)", seconds)
+        time.sleep(seconds)
+
+
+def parse_durable_result(payload):
+    """
+    Unwrap the invocation envelope returned by a synchronous boto3 ``invoke()`` of a durable function:
+    ``{"Status": "SUCCEEDED" | "FAILED" | "PENDING", "Result": <JSON string>, ...}``.
+
+    The business output of the durable handler is JSON-encoded inside ``Result`` when the ``Status``
+    is ``SUCCEEDED``. Payloads that are not durable envelopes are returned unchanged, so the callers
+    can treat durable and regular Lambdas uniformly. This helper is pure Python for the CALLER side:
+    the durable SDK is not required.
+
+    :param payload:         Parsed JSON payload of the Lambda invocation response.
+    :return:                The unwrapped result of the durable execution (or the original payload).
+    :raises RuntimeError:   If the durable execution FAILED, is still PENDING, or the ``Result``
+                            is empty or not valid JSON.
+    """
+
+    if not isinstance(payload, dict):
+        return payload
+
+    status = payload.get('Status')
+    if status not in ('SUCCEEDED', 'FAILED', 'PENDING'):
+        return payload
+
+    if status == 'FAILED':
+        error = payload.get('Error')
+        raise RuntimeError(f"Durable execution failed: {json.dumps(error) if error is not None else 'unknown'}")
+
+    if status == 'PENDING':
+        raise RuntimeError("Durable execution returned Status=PENDING: "
+                           "the synchronous invoke did not receive a final result.")
+
+    # Status == 'SUCCEEDED'
+    result = payload.get('Result')
+    if result is None or (isinstance(result, str) and not result.strip()):
+        raise RuntimeError("Durable execution SUCCEEDED with an empty Result. Results over the checkpoint "
+                           "size limit are not returned via Invoke. Check the logs of the durable function.")
+
+    if isinstance(result, dict):
+        return result
+
+    if isinstance(result, str):
+        try:
+            return json.loads(result)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Durable execution Result is not valid JSON: {e}") from e
+
+    raise RuntimeError(f"Unexpected type of durable execution Result: {type(result).__name__}")

--- a/sosw/test/suite_unit.py
+++ b/sosw/test/suite_unit.py
@@ -1,6 +1,7 @@
 # Core applications
 from .unit.test_app import app_UnitTestCase
 from .unit.test_deprecations import Deprecations_UnitTestCase
+from .unit.test_durable import durable_UnitTestCase, durable_WithFakeSdk_UnitTestCase
 from .unit.test_labourer import Labourer_UnitTestCase
 from .unit.test_lambda_api import lambda_api_UnitTestCase
 from .unit.test_orchestrator import Orchestrator_UnitTestCase
@@ -28,6 +29,8 @@ def suite():
     # Core applications
     test_suite.addTest(unittest.makeSuite(app_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Deprecations_UnitTestCase))
+    test_suite.addTest(unittest.makeSuite(durable_UnitTestCase))
+    test_suite.addTest(unittest.makeSuite(durable_WithFakeSdk_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Labourer_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(lambda_api_UnitTestCase))
     test_suite.addTest(unittest.makeSuite(Orchestrator_UnitTestCase))

--- a/sosw/test/unit/test_app.py
+++ b/sosw/test/unit/test_app.py
@@ -107,6 +107,71 @@ class app_UnitTestCase(unittest.TestCase):
         mock_ssm.assert_called_once_with('test_func_config')
 
 
+    @patch("sosw.app.get_config")
+    def test_init__test_flag_precedence(self, mock_ssm):
+        """
+        An explicitly passed `test` flag must always win. Otherwise the flag is derived from STAGE.
+        """
+
+        mock_ssm.return_value = {}
+
+        matrix = [
+            # (explicit_flag, stage, expected)
+            (True, 'test', True),
+            (False, 'test', False),
+            (None, 'test', True),
+            (True, 'prod', True),
+            (False, 'prod', False),
+            (None, 'prod', False),
+        ]
+
+        for explicit_flag, stage, expected in matrix:
+            with self.subTest(explicit_flag=explicit_flag, stage=stage):
+                kwargs = {} if explicit_flag is None else {'test': explicit_flag}
+                with patch.dict(os.environ, {'STAGE': stage}):
+                    processor = Processor(custom_config=self.TEST_CONFIG, **kwargs)
+                self.assertEqual(processor.test, expected)
+
+
+    @patch("sosw.app.get_config")
+    def test_init_config__disable_ddb_config__from_custom_config(self, mock_ssm):
+
+        os.environ['AWS_LAMBDA_FUNCTION_NAME'] = 'test_func'
+
+        processor = Processor(custom_config={'disable_ddb_config': True, 'foo': 'bar'})
+
+        mock_ssm.assert_not_called()
+        self.assertEqual(processor.config['foo'], 'bar', "custom_config must still be applied")
+
+
+    @patch("sosw.app.get_config")
+    def test_init_config__disable_ddb_config__from_class_attribute(self, mock_ssm):
+
+        class NoDdbConfigProcessor(Processor):
+            DISABLE_DDB_CONFIG = True
+
+        os.environ['AWS_LAMBDA_FUNCTION_NAME'] = 'test_func'
+
+        processor = NoDdbConfigProcessor(custom_config=self.TEST_CONFIG)
+
+        mock_ssm.assert_not_called()
+        self.assertEqual(processor.config['test'], True, "custom_config must still be applied")
+
+
+    @patch("sosw.app.get_config")
+    def test_init_config__disable_ddb_config__from_default_config(self, mock_ssm):
+
+        class DefaultsProcessor(Processor):
+            DEFAULT_CONFIG = {'disable_ddb_config': True, 'some_default': 42}
+
+        os.environ['AWS_LAMBDA_FUNCTION_NAME'] = 'test_func'
+
+        processor = DefaultsProcessor()
+
+        mock_ssm.assert_not_called()
+        self.assertEqual(processor.config['some_default'], 42, "DEFAULT_CONFIG must still be applied")
+
+
     # @unittest.skip("https://github.com/bimpression/sosw/issues/40")
     # def test__account(self):
     #     raise NotImplementedError
@@ -136,6 +201,106 @@ class app_UnitTestCase(unittest.TestCase):
             self.assertEqual(result, 'success')
             self.assertEqual(global_vars.processor.stats['total_processor_calls'], i + 1)
             self.assertEqual(global_vars.processor.stats['total_calls_register_clients'], 1)
+
+
+    def test_lambda_handler__test_flag_precedence(self):
+        """
+        The `test` key of the event must always win. Otherwise the flag is derived from STAGE.
+        """
+
+        matrix = [
+            # (event_test_key, stage, expected)
+            (True, 'test', True),
+            (False, 'test', False),
+            (None, 'test', True),
+            (True, 'prod', True),
+            (False, 'prod', False),
+            (None, 'prod', False),
+        ]
+
+        for event_flag, stage, expected in matrix:
+            with self.subTest(event_flag=event_flag, stage=stage):
+                global_vars = LambdaGlobals()
+                global_vars.processor = None
+
+                processor_class = MagicMock()
+                lambda_handler = get_lambda_handler(processor_class, global_vars, self.TEST_CONFIG)
+
+                event = {'k': 'v'} if event_flag is None else {'k': 'v', 'test': event_flag}
+                with patch.dict(os.environ, {'STAGE': stage}):
+                    lambda_handler(event=event, context=MagicMock())
+
+                processor_class.assert_called_once_with(custom_config=self.TEST_CONFIG, test=expected)
+
+
+    def test_lambda_handler__non_dict_event(self):
+        """
+        The handler must accept non-dict payloads: the `test` flag then derives from STAGE only.
+        """
+
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        processor_class = MagicMock()
+        lambda_handler = get_lambda_handler(processor_class, global_vars, self.TEST_CONFIG)
+
+        with patch.dict(os.environ, {'STAGE': 'prod'}):
+            lambda_handler(event=['not', 'a', 'dict'], context=MagicMock())
+
+        processor_class.assert_called_once_with(custom_config=self.TEST_CONFIG, test=False)
+
+
+    def test_lambda_handler__caches_processor_across_invocations(self):
+        """
+        Warm start contract: the Processor is constructed on the cold start only and then reused.
+        """
+
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        processor_class = MagicMock()
+        lambda_handler = get_lambda_handler(processor_class, global_vars, self.TEST_CONFIG)
+
+        lambda_handler(event={'k': 1}, context=MagicMock())
+        first_processor = global_vars.processor
+        lambda_handler(event={'k': 2}, context=MagicMock())
+
+        processor_class.assert_called_once()
+        self.assertIs(global_vars.processor, first_processor)
+
+
+    def test_lambda_handler__resets_stats_once_per_invocation(self):
+        """
+        `reset_stats()` must be called exactly once per invocation, recursively.
+        """
+
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        processor_class = MagicMock()
+        lambda_handler = get_lambda_handler(processor_class, global_vars, self.TEST_CONFIG)
+
+        lambda_handler(event={'k': 1}, context=MagicMock())
+        processor_instance = processor_class.return_value
+        processor_instance.reset_stats.assert_called_once_with(recursive=True)
+
+        lambda_handler(event={'k': 2}, context=MagicMock())
+        self.assertEqual(processor_instance.reset_stats.call_count, 2)
+
+
+    @patch.object(logger, 'error')
+    def test_get_lambda_handler__missing_global_vars(self, mock_logger_error):
+        """
+        Missing global_vars is reported, but the handler must still work on the module-level globals.
+        """
+
+        processor_class = MagicMock()
+        lambda_handler = get_lambda_handler(processor_class)
+
+        mock_logger_error.assert_called_once()
+
+        lambda_handler(event={'k': 1}, context=MagicMock())
+        processor_class.assert_called_once()
 
 
     def test_property_account__initialized_from_context(self):

--- a/sosw/test/unit/test_durable.py
+++ b/sosw/test/unit/test_durable.py
@@ -1,0 +1,307 @@
+import importlib
+import os
+import subprocess
+import sys
+import types
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+os.environ["STAGE"] = "test"
+os.environ["autotest"] = "True"
+
+import sosw.app
+import sosw.durable
+
+from sosw.app import LambdaGlobals, Processor
+
+
+SDK_NAME = 'aws_durable_execution_sdk_python'
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+
+def make_fake_sdk():
+    """
+    Build a fake `aws_durable_execution_sdk_python` module pair exposing the decorator surface
+    used by `sosw.durable`: `durable_execution` and `durable_step` in the root module and
+    `Duration` in the `config` submodule.
+    """
+
+    root = types.ModuleType(SDK_NAME)
+    config = types.ModuleType(f"{SDK_NAME}.config")
+
+    def fake_durable_execution(func, **kwargs):
+        def wrapper(event, context):
+            return func(event, context)
+
+        wrapper.durable_wrapped = func
+        wrapper.durable_kwargs = kwargs
+        return wrapper
+
+    root.durable_execution = MagicMock(side_effect=fake_durable_execution)
+    root.durable_step = MagicMock(name='durable_step')
+    root.config = config
+    config.Duration = MagicMock(name='Duration')
+
+    return root, config
+
+
+class durable_UnitTestCase(unittest.TestCase):
+    """
+    Tests of `sosw.durable` with the durable SDK NOT installed. This is the natural state of the
+    unit test environment: the SDK is an optional extra of sosw and must never be required here.
+    """
+
+
+    def setUp(self):
+        # Block the SDK import even if somebody installed the real SDK into the test environment.
+        # `None` in sys.modules forces an ImportError for the module and its submodules.
+        for name in [SDK_NAME, f"{SDK_NAME}.config"]:
+            sys.modules.pop(name, None)
+            sys.modules[name] = None
+
+        self.durable = importlib.reload(sosw.durable)
+
+
+    def tearDown(self):
+        for name in [SDK_NAME, f"{SDK_NAME}.config"]:
+            sys.modules.pop(name, None)
+        importlib.reload(sosw.durable)
+
+        # global_vars.processor and lambda_context are properties over module-level globals. Reset them.
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+
+    def test_module_imports_without_sdk(self):
+        self.assertFalse(self.durable.DURABLE_SDK_AVAILABLE)
+        self.assertIsNone(self.durable.durable_execution)
+        self.assertIsNone(self.durable.durable_step)
+        self.assertIsNone(self.durable.Duration)
+
+
+    def test_get_durable_lambda_handler__raises_helpful_import_error(self):
+        with self.assertRaises(ImportError) as cm:
+            self.durable.get_durable_lambda_handler(MagicMock(), LambdaGlobals(), {'test': True})
+
+        self.assertIn('pip install sosw[durable]', str(cm.exception))
+
+
+    def test_import_sosw_app__does_not_import_sdk(self):
+        """
+        `import sosw.app` must never pull the durable SDK: zero overhead for non-durable functions.
+        Verified in a pristine interpreter so that this test does not depend on the state of ours.
+        """
+
+        code = ("import sys\n"
+                "import sosw.app\n"
+                f"raise SystemExit(1 if '{SDK_NAME}' in sys.modules else 0)\n")
+
+        completed = subprocess.run([sys.executable, '-c', code], cwd=REPO_ROOT,
+                                   capture_output=True, text=True, timeout=120)
+
+        self.assertEqual(completed.returncode, 0,
+                         f"`import sosw.app` must not import the durable SDK. Stderr: {completed.stderr}")
+
+
+    @patch("sosw.durable.time")
+    def test_durable_wait__falls_back_to_sleep__no_context(self, mock_time):
+        global_vars = LambdaGlobals()
+
+        self.durable.durable_wait(3, global_vars=global_vars)
+
+        mock_time.sleep.assert_called_once_with(3)
+
+
+    @patch("sosw.durable.time")
+    def test_durable_wait__falls_back_to_sleep__context_without_wait(self, mock_time):
+        global_vars = LambdaGlobals()
+        global_vars.lambda_context = object()   # A regular LambdaContext has no `wait` operation.
+
+        self.durable.durable_wait(4, global_vars=global_vars)
+
+        mock_time.sleep.assert_called_once_with(4)
+
+
+    @patch("sosw.durable.time")
+    def test_durable_wait__falls_back_to_sleep__waitable_context_but_no_sdk(self, mock_time):
+        """Without the SDK there is no Duration to construct, so we must sleep even if ctx can wait."""
+
+        global_vars = LambdaGlobals()
+        global_vars.lambda_context = MagicMock()
+
+        self.durable.durable_wait(5, global_vars=global_vars)
+
+        mock_time.sleep.assert_called_once_with(5)
+        global_vars.lambda_context.wait.assert_not_called()
+
+
+    @patch("sosw.durable.time")
+    def test_durable_wait__defaults_to_module_global_vars(self, mock_time):
+        sosw.app.global_vars.lambda_context = None
+
+        self.durable.durable_wait(1)
+
+        mock_time.sleep.assert_called_once_with(1)
+
+
+    def test_parse_durable_result__succeeded_with_json_string(self):
+        payload = {'Status': 'SUCCEEDED', 'Result': '{"a": 1}'}
+        self.assertEqual(self.durable.parse_durable_result(payload), {'a': 1})
+
+
+    def test_parse_durable_result__succeeded_with_dict_result(self):
+        payload = {'Status': 'SUCCEEDED', 'Result': {'a': 1}}
+        self.assertEqual(self.durable.parse_durable_result(payload), {'a': 1})
+
+
+    def test_parse_durable_result__succeeded_with_non_dict_json(self):
+        payload = {'Status': 'SUCCEEDED', 'Result': '"hello"'}
+        self.assertEqual(self.durable.parse_durable_result(payload), 'hello')
+
+
+    def test_parse_durable_result__passes_through_non_envelopes(self):
+        for payload in [{'foo': 'bar'}, {'Status': 'OK', 'Result': 1}, ['a', 'b'], 'raw', 42, None]:
+            with self.subTest(payload=payload):
+                self.assertEqual(self.durable.parse_durable_result(payload), payload)
+
+
+    def test_parse_durable_result__failed(self):
+        payload = {'Status': 'FAILED', 'Error': {'Message': 'boom'}}
+
+        with self.assertRaises(RuntimeError) as cm:
+            self.durable.parse_durable_result(payload)
+
+        self.assertIn('boom', str(cm.exception))
+
+
+    def test_parse_durable_result__failed_without_error_details(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.durable.parse_durable_result({'Status': 'FAILED'})
+
+        self.assertIn('unknown', str(cm.exception))
+
+
+    def test_parse_durable_result__pending(self):
+        with self.assertRaises(RuntimeError):
+            self.durable.parse_durable_result({'Status': 'PENDING'})
+
+
+    def test_parse_durable_result__succeeded_with_empty_result(self):
+        for payload in [{'Status': 'SUCCEEDED'}, {'Status': 'SUCCEEDED', 'Result': ''},
+                        {'Status': 'SUCCEEDED', 'Result': '   '}]:
+            with self.subTest(payload=payload):
+                with self.assertRaises(RuntimeError):
+                    self.durable.parse_durable_result(payload)
+
+
+    def test_parse_durable_result__succeeded_with_invalid_json(self):
+        with self.assertRaises(RuntimeError):
+            self.durable.parse_durable_result({'Status': 'SUCCEEDED', 'Result': '{not json'})
+
+
+    def test_parse_durable_result__succeeded_with_unexpected_result_type(self):
+        with self.assertRaises(RuntimeError):
+            self.durable.parse_durable_result({'Status': 'SUCCEEDED', 'Result': 42})
+
+
+class durable_WithFakeSdk_UnitTestCase(unittest.TestCase):
+    """
+    Tests of `sosw.durable` with a FAKE durable SDK injected into sys.modules. Covers the code paths
+    that require the SDK without ever installing it in the unit test environment.
+    """
+
+    TEST_CONFIG = {'test': True}
+
+
+    class Child(Processor):
+        def __call__(self, event):
+            super().__call__(event)
+            return event.get('k')
+
+
+    def setUp(self):
+        self.fake_root, self.fake_config = make_fake_sdk()
+        sys.modules[SDK_NAME] = self.fake_root
+        sys.modules[f"{SDK_NAME}.config"] = self.fake_config
+
+        self.durable = importlib.reload(sosw.durable)
+
+
+    def tearDown(self):
+        sys.modules.pop(SDK_NAME, None)
+        sys.modules.pop(f"{SDK_NAME}.config", None)
+        importlib.reload(sosw.durable)
+
+        # global_vars.processor and lambda_context are properties over module-level globals. Reset them.
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+
+    def test_sdk_surface_is_reexported(self):
+        self.assertTrue(self.durable.DURABLE_SDK_AVAILABLE)
+        self.assertIs(self.durable.durable_execution, self.fake_root.durable_execution)
+        self.assertIs(self.durable.durable_step, self.fake_root.durable_step)
+        self.assertIs(self.durable.Duration, self.fake_config.Duration)
+
+
+    def test_get_durable_lambda_handler__wraps_handler(self):
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        handler = self.durable.get_durable_lambda_handler(MagicMock(), global_vars, self.TEST_CONFIG)
+
+        self.fake_root.durable_execution.assert_called_once()
+        args, kwargs = self.fake_root.durable_execution.call_args
+        self.assertTrue(callable(args[0]))
+        self.assertEqual(kwargs, {})
+        self.assertIs(handler.durable_wrapped, args[0], "The returned handler must be the decorated one")
+
+
+    def test_get_durable_lambda_handler__passes_durable_kwargs(self):
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        handler = self.durable.get_durable_lambda_handler(MagicMock(), global_vars, None,
+                                                          timeout=900, retries=2)
+
+        args, kwargs = self.fake_root.durable_execution.call_args
+        self.assertEqual(kwargs, {'timeout': 900, 'retries': 2})
+        self.assertEqual(handler.durable_kwargs, {'timeout': 900, 'retries': 2})
+
+
+    def test_durable_handler__executes_processor_lifecycle(self):
+        """
+        The wrapped handler must keep the exact non-durable Processor lifecycle:
+        warm-start cache of the Processor, fresh lambda_context and stats reset per invocation.
+        """
+
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+
+        handler = self.durable.get_durable_lambda_handler(self.Child, global_vars, self.TEST_CONFIG)
+
+        mock_context = MagicMock()
+        mock_context.invoked_function_arn = 'arn:aws:lambda:us-east-1:123456789012:function:example:42'
+
+        for i in range(2):
+            result = handler(event={'k': 'success'}, context=mock_context)
+            self.assertEqual(result, 'success')
+            self.assertEqual(type(global_vars.processor), self.Child)
+            self.assertEqual(global_vars.lambda_context, mock_context)
+            self.assertEqual(global_vars.processor.stats['total_processor_calls'], i + 1)
+
+
+    def test_durable_wait__uses_context_wait(self):
+        global_vars = LambdaGlobals()
+        ctx = MagicMock()
+        global_vars.lambda_context = ctx
+
+        self.durable.durable_wait(7, global_vars=global_vars)
+
+        self.fake_config.Duration.assert_called_once_with(seconds=7)
+        ctx.wait.assert_called_once_with(self.fake_config.Duration.return_value)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Part of the **sosw 3.0.0** release. Spec: `.kiro/specs/hq-692-sosw-3-0-0/` (R3, R5; design §3, §5). Closes #387.

## What
**Warm start (`sosw/app.py`)** — behavior-preserving except three deliberate fixes:
- Shared `_make_lambda_handler(...)` extracted; `get_lambda_handler` delegates with an unchanged signature and now documents the container-caching contract.
- **Test-flag precedence bug fixed** in both `Processor.__init__` and the handler: `kwargs.get('test') or True if STAGE... else False` parsed as `A or (B if C else D)` — an explicit `test=False` was ignored in test stages. Explicit flag now always wins.
- **Single `reset_stats(recursive=True)`** per invocation (was called twice).
- **`disable_ddb_config`**: skip the per-function DynamoDB/SSM config lookup via class attr, `DEFAULT_CONFIG`, or `custom_config` — absorbs the idea from #376.

**Durable execution (`sosw/durable.py`, new)** — matches the pattern already proven by five production durable Lambdas in a sibling org:
- `get_durable_lambda_handler(processor_class, ..., **durable_kwargs)` wraps the shared handler with the SDK's `durable_execution`.
- SDK strictly optional: module imports cleanly without it; the factory raises a helpful `ImportError` → `pip install sosw[durable]`. `sosw.app` has zero SDK knowledge (subprocess-proven).
- `durable_wait(seconds)` (context wait / `time.sleep` fallback) and `parse_durable_result(payload)` (SUCCEEDED unwrap; FAILED/PENDING/invalid → RuntimeError; passthrough for non-envelopes).

## Verification
- Suite **without the SDK installed**: `298 passed, 2 skipped, 28 subtests` (baseline 267). `durable.py` at 100% coverage; every added `app.py` line covered.
- **Zero existing-test changes needed** — audited: double-reset was idempotent for `total_*`; no test passed explicit `test=False`; `disable_ddb_config` defaults off.

## Flags for other streams
- Same precedence-bug pattern exists in `components/sns.py:82` and `components/config.py:527` (coverage stream will fix+test).
- `suite_unit.py` `__main__` path uses `unittest.makeSuite` (removed in 3.13) — pre-existing, pytest unaffected.
- Packaging extras `sosw[durable]` ship in #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)