### PR TITLE
3.0.0: AGENTS.md + cookiecutter + layer example (work stream 8)

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -24,7 +24,8 @@ Processor, components, helpers — is the product.
 ## Users
 
 - Engineering teams standardizing many small Lambdas on one config/stats/testing pattern.
-- AI coding agents scaffolding new Lambdas (see `AGENTS.md` and the cookiecutter template).
+- AI coding agents scaffolding new Lambdas — entry points: `AGENTS.md` (agent instructions),
+  `cookiecutter/` (project template), `examples/layers/sosw/` (Lambda layer build/deploy scripts).
 
 ## Quality bars
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -22,7 +22,9 @@ sosw/                     # the package
     └── variables.py, helpers_test*.py  # shared fixtures/mocks
 
 docs/                     # Sphinx documentation (docs.sosw.app), built with -W in CI
-examples/                 # runnable examples (SAM, workers, layers, cookiecutter usage)
+examples/                 # runnable examples (SAM, essentials, workers, yaml)
+│   └── layers/sosw/      # Lambda layer: build.sh + deploy.sh + README (SSM: lambda-layer-sosw-latest)
+cookiecutter/             # cookiecutter template for a new sosw-based Lambda (Processor / LambdaApi)
 .github/workflows/        # Tests / Docs / TestPyPI RC / PyPI release
 .kiro/specs/              # feature specs (requirements/design/tasks) — committed
 .kiro/steering/           # this steering set
@@ -35,3 +37,5 @@ AGENTS.md                 # instructions for AI coding agents working on/with so
 - Deprecated modules: bugfixes only; no new features; do not remove before 4.0.
 - Public API changes require a spec under `.kiro/specs/` and a docs update in the same release.
 - `examples/` content must actually run against the published package version it ships with.
+- `AGENTS.md` and `cookiecutter/` mirror the public API and conventions — update them in the same
+  PR that changes signatures or config behavior (the generated project's tests must keep passing).

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -33,7 +33,16 @@
 
 ## CI/CD
 
-- GitHub Workflows only (Travis is gone): Tests matrix 3.10–3.14 + coverage job, Docs build (Sphinx),
-  TestPyPI RC publish on staging branches (`X_Y_Z`), PyPI publish on push to `master`.
+- GitHub Workflows only (Travis is gone): Tests matrix 3.10–3.14 + coverage job (100%), Docs build
+  (Sphinx `-W`), TestPyPI RC publish on staging branches (`X_Y_Z`), PyPI publish on push to `master`.
 - Staging-branch flow: feature branches → PR into the current `X_Y_Z` staging branch → release PR
   `X_Y_Z → master`. Merging to master publishes to PyPI.
+
+## Bootstrap artifacts (ship with the repo, must track the API)
+
+- `AGENTS.md` — coding-agent instructions; encodes the build/test/debug/style conventions.
+- `cookiecutter/` — project template scaffolding a sosw-based Lambda (plain Processor or LambdaApi
+  variant); generated projects' unit tests must pass against the current package.
+- `examples/layers/sosw/` — Lambda layer build/deploy scripts (sosw + boto3, default-on
+  powertools/xray extras; SSM pointer `lambda-layer-sosw-latest`).
+- A PR changing public API signatures or config conventions updates these in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,329 @@
+# AGENTS.md
+
+Instructions for AI coding agents. Two audiences, one file: agents **building AWS Lambda functions
+on top of `sosw`**, and agents **contributing to this repository**. Human docs: https://docs.sosw.app
+
+## What sosw is
+
+Since 3.0.0 `sosw` is a **framework for bootstrapping AWS Lambda functions**: a `Processor` base
+class with layered configuration, statistics, and warm-start container reuse, plus thin middleware
+components for AWS services. The legacy orchestration layer ("Serverless Orchestrator of Serverless
+Workers", pre-3.0) is deprecated: functional through 3.x, warns on instantiation, removed in 4.0.
+Do not build anything new on the deprecated entities.
+
+The only mandatory runtime dependency is `boto3`. Supported Python: 3.10–3.14.
+
+## Package map
+
+| Module | Status | One-liner |
+|---|---|---|
+| `sosw/app.py` | CORE | `Processor` base class, `LambdaGlobals`, `get_lambda_handler` (warm-start caching handler factory) |
+| `sosw/lambda_api.py` | CORE | `LambdaApi(Processor)`: declarative router for Lambdas behind API Gateway (REST v1 + HTTP v2), Cognito claims, CORS, JSON envelopes |
+| `sosw/durable.py` | CORE, optional dep | `get_durable_lambda_handler` for AWS Lambda durable execution (`pip install sosw[durable]`) + SDK-optional helpers |
+| `sosw/components/` | COMPONENT | AWS middleware: `config`, `dynamo_db`, `sns`, `siblings`, `sigv4`, `exceptions` (incl. `ApiError` hierarchy), `benchmark`, `helpers` |
+| `sosw/orchestrator.py`, `scheduler.py`, `scavenger.py`, `worker.py`, `worker_assistant.py`, `labourer.py`, `essential.py`, `sosw/managers/` | DEPRECATED | self-hosted orchestration; bugfixes only, removed in 4.0 — prefer Step Functions / EventBridge / durable execution |
+
+Bootstrap tooling: `cookiecutter/` (project template — see its README) and `examples/layers/sosw/`
+(Lambda layer build + deploy scripts).
+
+## Build a Lambda on sosw
+
+Import from concrete modules: `from sosw.app import Processor` — not `from sosw import Processor`
+(the package init is a lazy façade kept for compatibility).
+
+### Minimal Processor Lambda
+
+```python
+"""src/app.py"""
+
+import logging
+
+from sosw.app import LambdaGlobals, get_lambda_handler
+from sosw.app import Processor as SoswProcessor
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class Processor(SoswProcessor):
+
+    DEFAULT_CONFIG = {
+        'init_clients': [],     # e.g. ['DynamoDb', 'Sns'] — registered as self.dynamo_db_client, ...
+    }
+
+
+    def __call__(self, event):
+        super().__call__(event)     # counts the call, resets self.result
+
+        records = event.get('records', [])
+        for record in records:
+            self.process_record(record)
+
+        self.result['processed'] = len(records)
+        return dict(self.result)
+
+
+    def process_record(self, record):
+        logger.info("Processing record: %s", record)
+        self.stats['records_processed'] += 1
+
+
+global_vars = LambdaGlobals()
+lambda_handler = get_lambda_handler(Processor, global_vars)
+```
+
+Rules that follow from the warm-start contract:
+
+- `get_lambda_handler` caches the Processor instance in `global_vars` and **reuses it across warm
+  invocations** for the container lifetime. Never keep per-invocation state on `self` attributes or
+  mutable class attributes (`failed: list = []` is a bug) — it leaks into the next event.
+- `self.result` is the per-invocation accumulator — reset on every `__call__` (via
+  `super().__call__(event)`).
+- `self.stats` is the container-lifetime counter. The handler calls `reset_stats()` after every
+  invocation: plain counters are rolled up into `total_*` keys, `total_*` and keys listed in the
+  `lifetime_stats_params` config survive as-is.
+
+### Configuration
+
+`Processor.init_config()` builds `self.config` in three layers, each recursively updating the previous:
+
+1. `DEFAULT_CONFIG` class attribute;
+2. the per-function config `{AWS_LAMBDA_FUNCTION_NAME}_config` fetched from the DynamoDB `config`
+   table (or SSM, depending on the configured source) — this is how you change behavior of a
+   deployed Lambda without redeploying;
+3. `custom_config` passed to the constructor (usually via `get_lambda_handler(..., custom_config=...)`).
+
+Skip layer 2 (no DDB/SSM lookup, e.g. for Lambdas without such permissions) by setting the class
+attribute `DISABLE_DDB_CONFIG = True`, or a truthy `disable_ddb_config` key in `DEFAULT_CONFIG` or
+`custom_config`.
+
+Read nested config values with the shortcut `self._c('path.to.param', default)`.
+
+DynamoDB access: declare `{prefix}_dynamo_db_config` in the config and call
+`self.get_ddbc('{prefix}')` to lazily get a configured `DynamoDbClient`.
+
+### HTTP API Lambda: LambdaApi
+
+For functions behind API Gateway subclass `sosw.lambda_api.LambdaApi` and declare routes in config:
+
+```python
+"""src/app.py"""
+
+from sosw.app import LambdaGlobals, get_lambda_handler
+from sosw.components.exceptions import NotFoundError
+from sosw.lambda_api import LambdaApi
+
+
+class Processor(LambdaApi):
+
+    DEFAULT_CONFIG = {
+        'auth_enabled': True,       # requires Cognito claims injected by the API Gateway authorizer
+        'routes':       {
+            'GET /things':            'list_things',
+            'GET /things/{thing_id}': 'get_thing',
+            'POST /things':           'create_thing',
+        },
+    }
+
+
+    def list_things(self, event, **kwargs):
+        return {'things': []}
+
+
+    def get_thing(self, event, thing_id=None, **kwargs):
+        if thing_id != '42':
+            raise NotFoundError(f"Thing {thing_id} does not exist")
+        return {'thing_id': thing_id}
+
+
+    def create_thing(self, event, **kwargs):
+        return self.make_response({'created': True}, status_code=201)
+
+
+global_vars = LambdaGlobals()
+lambda_handler = get_lambda_handler(Processor, global_vars)
+```
+
+- Handlers get the raw event plus path parameters as kwargs. Return any JSON-serializable object
+  (rendered as `200` with configured CORS headers; `Decimal`/`datetime`/`set` are encoded for you),
+  a pre-rendered `{'statusCode': ...}` dict (passed through), or raise an
+  `ApiError` subclass from `sosw.components.exceptions` — `BadRequestError` 400,
+  `UnauthorizedError` 401, `ForbiddenError` 403, `NotFoundError` 404, `ConflictError` 409,
+  `ServerError` 500.
+- Auth: the API Gateway authorizer verifies the JWT; `LambdaApi` extracts claims (v1 and v2 shapes)
+  into `self.claims`, rejects missing/expired claims with 401, and — when the `authorized_groups`
+  config is non-empty — rejects callers outside those Cognito groups with 403. Override
+  `check_route_access(route, claims)` for per-route RBAC.
+- Config knobs: `auth_enabled`, `authorized_groups`, `cors_headers`, `path_prefixes`.
+
+### Durable functions
+
+For long multi-step workflows on AWS Lambda durable execution mode:
+
+```python
+from sosw.durable import get_durable_lambda_handler
+
+global_vars = LambdaGlobals()
+lambda_handler = get_durable_lambda_handler(Processor, global_vars)
+```
+
+- Requires the optional SDK: `pip install sosw[durable]`. Regular functions keep using
+  `get_lambda_handler`, which never imports the SDK.
+- Inside the Processor, `global_vars.lambda_context` is the `DurableContext`: use its `step()` /
+  `wait()` for checkpointed operations. `sosw.durable.durable_wait(seconds)` works in both worlds
+  (checkpointed wait when durable, `time.sleep` otherwise).
+- A synchronous `invoke()` of a durable function returns an envelope
+  `{"Status": "SUCCEEDED"|"FAILED"|"PENDING", "Result": "<JSON string>"}` — unwrap it on the caller
+  side with `sosw.durable.parse_durable_result(payload)` (pure Python, no SDK needed).
+
+### SAM packaging
+
+Ship the function with the `sosw` Lambda layer instead of bundling the package
+(see `examples/layers/sosw/`), referencing the layer ARN from SSM:
+
+```yaml
+Parameters:
+  LambdaLayerSoswLatestArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: lambda-layer-sosw-latest
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.lambda_handler
+      Layers:
+        - !Ref LambdaLayerSoswLatestArn
+```
+
+Or scaffold the whole project: `cookiecutter https://github.com/sosw/sosw --directory cookiecutter`.
+
+## Test
+
+### Pattern for Lambdas built on sosw
+
+Unit tests are pure: no network, no real AWS. Set the environment **before importing** anything
+that imports sosw, patch `boto3.client`, and patch the config lookup:
+
+```python
+"""test/test_unit.py"""
+
+import os
+import sys
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+os.environ['STAGE'] = 'test'
+os.environ['autotest'] = 'True'
+
+from app import Processor
+
+
+class ProcessorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patcher_boto = patch('boto3.client')
+        self.mock_boto_client = self.patcher_boto.start()
+        self.mock_boto_client.return_value = MagicMock()
+
+        with patch.object(Processor, 'get_config', return_value={}):
+            self.processor = Processor(test=True)
+
+
+    def tearDown(self):
+        self.patcher_boto.stop()
+        del self.processor
+
+
+    def test_call(self):
+        result = self.processor({'records': ['a', 'b']})
+        self.assertEqual(result['processed'], 2)
+```
+
+**Always add the container-reuse regression test.** Lambda containers are warm-reused, so the same
+Processor instance serves consecutive events; state leaks are the classic sosw bug. Invoke twice
+and assert the second result reflects only the second event:
+
+```python
+    def test_no_state_leak_between_invocations(self):
+        """Simulate a warm container: second call must not see first call's state."""
+        self.processor({'records': ['a', 'b', 'c']})
+        result = self.processor({'records': ['d']})
+
+        self.assertEqual(result['processed'], 1)    # 1, not 4 accumulated
+```
+
+### Contributing tests to sosw itself
+
+- `unittest.TestCase` style. Files live in `sosw/test/unit/`, `sosw/components/test/unit/`,
+  `sosw/managers/test/unit/`.
+- **Register every new unit test file in `sosw/test/suite_unit.py`** (import the TestCase and
+  `addTest` it) — CI runs only that explicit suite, pytest discovery is not used. An unregistered
+  test never runs.
+- Run the suite: `python -m pytest sosw/test/suite_unit.py -v`. Never run pytest over the whole
+  tree — legacy `test/integration/` files create real AWS resources.
+- Coverage is enforced at **100%** of `sosw/` (test dirs excluded via `.coveragerc`):
+  `python -m pytest sosw/test/suite_unit.py --cov=sosw --cov-report=term-missing`.
+  Cover optional-import guards (e.g. powertools) by reloading the module with a patched
+  `sys.modules`, not with `# pragma: no cover`.
+- Keep the suite fast (seconds) and network-free: `patch('boto3.client')`, `MagicMock()` clients,
+  `patch.object(Processor, 'get_config', return_value={...})`.
+
+## Debug
+
+- **Bump log verbosity per invocation**: pass `"logging_level": "DEBUG"` in the Lambda event —
+  the generated handler calls `logger.setLevel()` with it before processing.
+- **Contracts**: the handler returns whatever your `__call__` returns and logs `get_stats()` after
+  every invocation. Business output belongs in `self.result`; metrics/counters in `self.stats`.
+- Common failure modes:
+  - *Config silently empty*: if `{AWS_LAMBDA_FUNCTION_NAME}_config` does not exist in the DynamoDB
+    `config` table (or the function lacks read permissions), `get_config` returns `{}` — the
+    Processor proceeds with only `DEFAULT_CONFIG` + `custom_config`. If DDB config is intended,
+    verify the record name matches the deployed function name exactly.
+  - *`ValueError: get_ddbc() method supports only prefixes: [...]`*: you called
+    `self.get_ddbc('x')` but the final config has no `x_dynamo_db_config` key. Check which config
+    layer was supposed to deliver it.
+  - *LambdaApi never raises to the caller*: `LambdaApi.__call__` converts everything to an HTTP
+    response — `ApiError` subclasses to their status envelope
+    `{'error': {'code': ..., 'message': ...}}`, unexpected exceptions to a generic 500 (logged
+    server-side with full traceback, counted in `stats['api_errors_5xx']`). A 401/403 never
+    includes claim contents; look at the CloudWatch logs for the reason. Unknown route or method
+    is 404.
+  - *Durable result looks wrapped*: synchronous invokes of durable functions return the
+    `{"Status", "Result"}` envelope; unwrap with `parse_durable_result` — it raises `RuntimeError`
+    on `FAILED`/`PENDING`/empty results instead of handing you the envelope.
+  - *State from the previous event*: warm container reuse (see the regression test above).
+
+## Style rules for contributions
+
+PRs violating these get bounced in review:
+
+- PEP-8 with **two blank lines** between functions/methods/classes; vertically aligned dict values.
+- **Single quotes** for regular strings and dict keys; **double quotes** for logging and exception
+  messages.
+- Logging via `%` formatting: `logger.info("Processing %s", thing)` — **never f-strings in logger
+  calls**.
+- Imports at the top of the module, grouped in order: full core imports, full custom imports,
+  partial core imports (`from x import y`), partial custom imports.
+- **Fail fast and loud**: no `try/except: pass` around business logic; Lambdas must raise on errors
+  (the only sanctioned exception-to-response conversion is the `LambdaApi` HTTP contract layer).
+- snake_case data fields in events/payloads/records.
+- reST docstrings (`:param x:`, `:rtype:`) on public callables; new `sosw` modules start with the
+  MIT license header docstring (copy it from `sosw/app.py`).
+- Every file ends with exactly one trailing newline.
+
+## Repo mechanics
+
+- Branch flow: feature branch → PR into the current **`X_Y_Z` staging branch** (e.g. `3_0_1`), not
+  into `master`. Pushes to staging branches publish release candidates to TestPyPI; merging the
+  release PR `X_Y_Z → master` publishes to PyPI. Never merge to `master` yourself.
+- CI gates on PRs: unit suite on Python 3.10–3.14, **100% coverage**, and a Sphinx docs build with
+  `-W` (any docs warning fails the build — update `docs/` in the same PR when you change public
+  API or docstrings referenced there).
+- Deprecated modules: bugfixes only, no new features, nothing removed before 4.0.
+- `examples/`, `cookiecutter/`, and `AGENTS.md` must track the public API: if your change alters
+  signatures or config conventions shown there, update them in the same PR.

--- a/cookiecutter/README.md
+++ b/cookiecutter/README.md
@@ -1,0 +1,56 @@
+# Cookiecutter template: AWS Lambda on sosw
+
+Scaffolds a complete, deployable AWS Lambda project built on the
+[`sosw`](https://github.com/sosw/sosw) framework: application code, pure unit tests,
+an AWS SAM template consuming the `sosw` Lambda layer, and deploy instructions.
+
+## Usage
+
+```bash
+pip install cookiecutter        # or: pipx install cookiecutter
+
+# Straight from GitHub:
+cookiecutter https://github.com/sosw/sosw --directory cookiecutter
+
+# Or from a local clone:
+cookiecutter path/to/sosw/cookiecutter
+```
+
+Answer the prompts (defaults in parentheses):
+
+| Option | Meaning |
+|---|---|
+| `project_slug` | Python-friendly project directory name (`my_sosw_lambda`) |
+| `function_name` | Lambda `FunctionName` and CloudFormation stack name, kebab-case (derived from the slug) |
+| `description` | One-line description used in the template and docstrings |
+| `python_version` | Lambda runtime version (`3.13`; also 3.10 / 3.11 / 3.12 / 3.14) |
+| `use_lambda_api` | `yes` scaffolds an HTTP API Lambda on `sosw.lambda_api.LambdaApi` (declarative routes, auth, JSON envelopes); `no` (default) scaffolds a plain event Processor |
+| `aws_region` | Region written to `samconfig.toml` |
+
+## What you get
+
+```
+my_sosw_lambda/
+├── src/
+│   └── app.py           # Processor (or LambdaApi) subclass + lambda_handler wiring
+├── test/
+│   └── test_unit.py     # pure unit tests: mocked boto3/config, warm-container regression test
+├── template.yaml        # AWS SAM template consuming the sosw layer from SSM
+├── samconfig.toml       # minimal SAM deploy configuration
+├── requirements.txt
+└── README.md            # build / test / deploy instructions
+```
+
+## After generation
+
+```bash
+cd my_sosw_lambda
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt pytest
+python -m pytest test/ -q          # tests pass out of the box, no AWS needed
+sam build && sam deploy --parameter-overrides Stage=dev    # first deploy to an account
+```
+
+The SAM template expects the `sosw` Lambda layer ARN in the SSM parameter
+`lambda-layer-sosw-latest` — publish it once per account/region with the scripts in
+[`examples/layers/sosw/`](../examples/layers/sosw/).

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -1,0 +1,12 @@
+{
+    "project_slug":      "my_sosw_lambda",
+    "function_name":     "{{ cookiecutter.project_slug | replace('_', '-') }}",
+    "description":       "AWS Lambda function built on the sosw framework.",
+    "python_version":    ["3.13", "3.10", "3.11", "3.12", "3.14"],
+    "use_lambda_api":    ["no", "yes"],
+    "aws_region":        "us-east-1",
+    "_jinja2_env_vars":  {
+        "trim_blocks":   true,
+        "lstrip_blocks": true
+    }
+}

--- a/cookiecutter/{{cookiecutter.project_slug}}/README.md
+++ b/cookiecutter/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,97 @@
+# {{ cookiecutter.function_name }}
+
+{{ cookiecutter.description }}
+
+Built on the [sosw](https://github.com/sosw/sosw) framework (docs: https://docs.sosw.app).
+
+## Layout
+
+```
+{{ cookiecutter.project_slug }}/
+├── src/app.py           # Processor + lambda_handler
+├── test/test_unit.py    # pure unit tests (no AWS access required)
+├── template.yaml        # AWS SAM template
+├── samconfig.toml       # SAM deploy configuration
+└── requirements.txt     # local development dependencies
+```
+
+## Prerequisites
+
+- AWS SAM CLI and AWS credentials for the target account.
+- The `sosw` Lambda layer published in the target account/region, with its ARN stored in the
+  SSM parameter `lambda-layer-sosw-latest`. Publish it once with the scripts in
+  [`examples/layers/sosw/`](https://github.com/sosw/sosw/tree/master/examples/layers/sosw)
+  of the sosw repository.
+- Optional: a DynamoDB table named `config` (keys: `env`, `config_name`) if you want to manage the
+  runtime configuration of the function without redeploying (see Runtime configuration below).
+
+## Test
+
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt pytest
+python -m pytest test/ -q
+```
+
+The tests are pure unit tests: `boto3` and the config lookup are mocked, so they run without any
+AWS access. They include the warm-container regression test — keep it passing when you add state.
+
+## Deploy
+
+```bash
+sam build
+sam deploy --parameter-overrides Stage=dev    # FIRST deploy to an account: pass Stage explicitly
+sam deploy                                    # subsequent deploys reuse the stack's Stage
+```
+{% if cookiecutter.use_lambda_api == 'yes' %}
+
+## API
+
+Routes are declared in `DEFAULT_CONFIG['routes']` of `src/app.py`:
+
+| Route | Handler |
+|---|---|
+| `GET /health` | `get_health` |
+| `GET /things/{thing_id}` | `get_thing` |
+
+```bash
+curl "$(sam list stack-outputs --output json | jq -r '.[] | select(.OutputKey=="ApiUrl") | .OutputValue')health"
+```
+
+Authorization: `auth_enabled` is on by default, so requests without Cognito claims get `401`.
+Either attach a Cognito JWT authorizer to the `HttpApi` resource in `template.yaml`:
+
+```yaml
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        DefaultAuthorizer: CognitoJwtAuthorizer
+        Authorizers:
+          CognitoJwtAuthorizer:
+            IdentitySource: $request.header.Authorization
+            JwtConfiguration:
+              issuer: !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/YOUR_USER_POOL_ID'
+              audience:
+                - YOUR_APP_CLIENT_ID
+```
+
+or, for a private/dev API without Cognito, set `'auth_enabled': False` in the config.
+{% endif %}
+
+## Runtime configuration
+
+`sosw` builds the effective config of the Processor in layers, each recursively updating the
+previous one:
+
+1. `DEFAULT_CONFIG` in `src/app.py`;
+2. the `{{ cookiecutter.function_name }}_config` record of the DynamoDB `config` table — change
+   the behavior of the deployed function without redeploying;
+3. `custom_config` passed to the constructor (used by the unit tests).
+
+No `config` table (or no permissions)? The lookup silently yields `{}`. If you do not use DynamoDB
+configs at all, set `'disable_ddb_config': True` in `DEFAULT_CONFIG` and drop the `ReadSoswConfig`
+policy statement from `template.yaml`.
+
+Debugging tip: pass `"logging_level": "DEBUG"` in the Lambda event to raise the log verbosity of a
+single invocation.

--- a/cookiecutter/{{cookiecutter.project_slug}}/requirements.txt
+++ b/cookiecutter/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,0 +1,3 @@
+# Local development and unit testing. At runtime the function imports sosw from the
+# Lambda layer referenced in template.yaml, so nothing is bundled with the code.
+sosw

--- a/cookiecutter/{{cookiecutter.project_slug}}/samconfig.toml
+++ b/cookiecutter/{{cookiecutter.project_slug}}/samconfig.toml
@@ -1,0 +1,8 @@
+version = 0.1
+
+[default.deploy.parameters]
+stack_name = "{{ cookiecutter.function_name }}"
+region = "{{ cookiecutter.aws_region }}"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+resolve_s3 = true

--- a/cookiecutter/{{cookiecutter.project_slug}}/src/app.py
+++ b/cookiecutter/{{cookiecutter.project_slug}}/src/app.py
@@ -1,0 +1,133 @@
+"""
+{{ cookiecutter.function_name }}
+{{ '=' * (cookiecutter.function_name | length) }}
+
+{{ cookiecutter.description }}
+
+Built on the ``sosw`` framework: https://docs.sosw.app
+"""
+
+try:
+    from aws_lambda_powertools import Logger
+
+    logger = Logger()
+
+except ImportError:
+    import logging
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+{% if cookiecutter.use_lambda_api == 'yes' %}
+from sosw.app import LambdaGlobals, get_lambda_handler
+from sosw.components.exceptions import NotFoundError
+from sosw.lambda_api import LambdaApi
+
+
+class Processor(LambdaApi):
+    """
+    HTTP API Lambda behind API Gateway (REST v1 or HTTP v2 proxy events).
+
+    ``LambdaApi`` dispatches requests declared in the ``routes`` config to the methods below,
+    validates Cognito claims injected by the API Gateway authorizer (``auth_enabled``), renders
+    JSON responses with the configured CORS headers, and converts raised ``ApiError`` subclasses
+    to their HTTP error envelopes.
+
+    The final config is built in layers: ``DEFAULT_CONFIG``, recursively updated with the
+    ``{{ cookiecutter.function_name }}_config`` record of the DynamoDB ``config`` table
+    (if present), recursively updated with the ``custom_config`` of the constructor.
+    """
+
+    DEFAULT_CONFIG = {
+        'auth_enabled': True,
+        'routes':       {
+            'GET /health':            'get_health',
+            'GET /things/{thing_id}': 'get_thing',
+        },
+        'things':       {
+            '42': 'The Answer',
+        },
+    }
+
+
+    def get_health(self, event, **kwargs):
+        """
+        Health check route. Requires a valid caller when ``auth_enabled`` is on.
+
+        :param dict event:  Raw API Gateway proxy event.
+        :rtype:             dict
+        """
+
+        logger.debug("Health check called by: %s", self.claims.get('sub', 'anonymous'))
+
+        return {'status': 'ok'}
+
+
+    def get_thing(self, event, thing_id=None, **kwargs):
+        """
+        Return a single thing by the ``thing_id`` path parameter.
+
+        Things live in the ``things`` config parameter for this scaffold - replace with real
+        storage (e.g. ``self.get_ddbc('things')`` backed by a DynamoDB table).
+
+        :param dict event:          Raw API Gateway proxy event.
+        :param str thing_id:        Path parameter extracted from the matched route.
+        :rtype:                     dict
+        :raises NotFoundError:      When the thing does not exist -> HTTP 404.
+        """
+
+        things = self._c('things') or {}
+
+        if thing_id not in things:
+            raise NotFoundError(f"Thing {thing_id} does not exist")
+
+        return {'thing_id': thing_id, 'thing': things[thing_id]}
+{% else %}
+from sosw.app import LambdaGlobals, get_lambda_handler
+from sosw.app import Processor as SoswProcessor
+
+
+class Processor(SoswProcessor):
+    """
+    Main worker of ``{{ cookiecutter.function_name }}``.
+
+    The final config is built in layers: ``DEFAULT_CONFIG``, recursively updated with the
+    ``{{ cookiecutter.function_name }}_config`` record of the DynamoDB ``config`` table
+    (if present), recursively updated with the ``custom_config`` of the constructor.
+
+    Warm-start contract: the instance is cached for the Lambda container lifetime, so
+    per-invocation state belongs in ``self.result`` (reset by ``super().__call__``) and
+    lifetime counters in ``self.stats``. Never accumulate per-event state on ``self``.
+    """
+
+    DEFAULT_CONFIG = {
+        'init_clients': [],
+    }
+
+
+    def __call__(self, event):
+        super().__call__(event)
+
+        records = event.get('records', [])
+        for record in records:
+            self.process_record(record)
+
+        self.result['processed'] = len(records)
+
+        return dict(self.result)
+
+
+    def process_record(self, record):
+        """
+        Process a single record. Replace with the real business logic.
+
+        :param record:  Element of the ``records`` list of the event.
+        """
+
+        logger.info("Processing record: %s", record)
+        self.stats['records_processed'] += 1
+{% endif %}
+
+
+global_vars = LambdaGlobals()
+lambda_handler = get_lambda_handler(Processor, global_vars)

--- a/cookiecutter/{{cookiecutter.project_slug}}/template.yaml
+++ b/cookiecutter/{{cookiecutter.project_slug}}/template.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: '{{ cookiecutter.description }}'
+
+
+Parameters:
+
+  Stage:
+    Type: String
+    AllowedValues: [dev, prod]
+    Description: Deployment stage. Pass explicitly on the first deploy to an account.
+
+  LambdaLayerSoswLatestArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: lambda-layer-sosw-latest
+    Description: SSM parameter holding the ARN of the latest sosw Lambda layer version.
+
+
+Resources:
+
+  {{ cookiecutter.project_slug | replace('_', ' ') | title | replace(' ', '') }}Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: {{ cookiecutter.function_name }}
+      Description: '{{ cookiecutter.description }}'
+      CodeUri: src/
+      Handler: app.lambda_handler
+      Runtime: python{{ cookiecutter.python_version }}
+      MemorySize: 128
+      Timeout: 30
+      Layers:
+        - !Ref LambdaLayerSoswLatestArn
+      Environment:
+        Variables:
+          STAGE: !Ref Stage
+      {% if cookiecutter.use_lambda_api == 'yes' %}
+      Events:
+        ApiProxy:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Method: ANY
+            Path: /{proxy+}
+      {% endif %}
+      Policies:
+        # The sosw Processor looks up the '{{ cookiecutter.function_name }}_config' record in the
+        # DynamoDB 'config' table on cold start. Remove this statement and set
+        # 'disable_ddb_config': True in DEFAULT_CONFIG if you do not use DynamoDB configs.
+        - Statement:
+            - Sid: ReadSoswConfig
+              Effect: Allow
+              Action:
+                - dynamodb:Query
+                - dynamodb:DescribeTable
+              Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/config'
+  {% if cookiecutter.use_lambda_api == 'yes' %}
+
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    # The application validates caller claims itself ('auth_enabled' in DEFAULT_CONFIG) and
+    # returns 401 for requests without them. To have API Gateway verify the JWTs, add an Auth
+    # section with your Cognito JWT authorizer here - see the README.
+  {% endif %}
+
+
+Outputs:
+
+  FunctionArn:
+    Description: ARN of the deployed Lambda function.
+    Value: !GetAtt {{ cookiecutter.project_slug | replace('_', ' ') | title | replace(' ', '') }}Function.Arn
+  {% if cookiecutter.use_lambda_api == 'yes' %}
+
+  ApiUrl:
+    Description: Invoke URL of the HTTP API.
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/'
+  {% endif %}

--- a/cookiecutter/{{cookiecutter.project_slug}}/test/test_unit.py
+++ b/cookiecutter/{{cookiecutter.project_slug}}/test/test_unit.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for ``{{ cookiecutter.function_name }}``.
+
+Pure unit tests: boto3 and the sosw config lookup are mocked, no network calls.
+Run from the project root: ``python -m pytest test/ -q`` (or ``python test/test_unit.py``).
+"""
+
+{% if cookiecutter.use_lambda_api == 'yes' %}
+import json
+{% endif %}
+import os
+import sys
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+os.environ['STAGE'] = 'test'
+os.environ['autotest'] = 'True'
+
+from app import Processor
+
+{% if cookiecutter.use_lambda_api == 'yes' %}
+
+CLAIMS = {'sub': 'test-user'}
+
+
+def make_apigw_event(path, method='GET', claims=None):
+    """
+    Build a minimal API Gateway HTTP API (payload v2) proxy event.
+
+    :param str path:        Request path, e.g. ``'/things/42'``.
+    :param str method:      HTTP method.
+    :param dict claims:     Cognito claims of the caller, or None for an unauthenticated request.
+    :rtype:                 dict
+    """
+
+    event = {
+        'rawPath':        path,
+        'requestContext': {'http': {'method': method}},
+    }
+
+    if claims is not None:
+        event['requestContext']['authorizer'] = {'jwt': {'claims': claims}}
+
+    return event
+
+
+class ProcessorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patcher_boto = patch('boto3.client')
+        self.mock_boto_client = self.patcher_boto.start()
+        self.mock_boto_client.return_value = MagicMock()
+
+        with patch.object(Processor, 'get_config', return_value={}):
+            self.processor = Processor(custom_config={'things': {'1': 'one', '2': 'two'}}, test=True)
+
+
+    def tearDown(self):
+        self.patcher_boto.stop()
+        del self.processor
+
+
+    def test_processor_initialization(self):
+        self.assertIsInstance(self.processor, Processor)
+
+
+    def test_health_route(self):
+        response = self.processor(make_apigw_event('/health', claims=CLAIMS))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {'status': 'ok'})
+
+
+    def test_missing_claims_return_401(self):
+        response = self.processor(make_apigw_event('/health'))
+
+        self.assertEqual(response['statusCode'], 401)
+
+
+    def test_unknown_route_returns_404(self):
+        response = self.processor(make_apigw_event('/nowhere', claims=CLAIMS))
+
+        self.assertEqual(response['statusCode'], 404)
+
+
+    def test_get_thing_extracts_path_parameter(self):
+        response = self.processor(make_apigw_event('/things/42', claims=CLAIMS))
+
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), {'thing_id': '42', 'thing': 'The Answer'})
+
+
+    def test_get_thing_missing_returns_404(self):
+        response = self.processor(make_apigw_event('/things/13', claims=CLAIMS))
+
+        self.assertEqual(response['statusCode'], 404)
+        self.assertEqual(json.loads(response['body'])['error']['code'], 'NOT_FOUND')
+
+
+    def test_no_state_leak_between_invocations(self):
+        """Simulate a warm container: the second response must reflect only the second request."""
+        self.processor(make_apigw_event('/things/1', claims=CLAIMS))
+        response = self.processor(make_apigw_event('/things/2', claims=CLAIMS))
+
+        self.assertEqual(json.loads(response['body']), {'thing_id': '2', 'thing': 'two'})
+
+
+    def test_no_claims_leak_between_invocations(self):
+        """Simulate a warm container: caller identity must not survive into the next invocation."""
+        self.processor(make_apigw_event('/health', claims=CLAIMS))
+        response = self.processor(make_apigw_event('/health'))
+
+        self.assertEqual(response['statusCode'], 401)
+{% else %}
+
+class ProcessorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.patcher_boto = patch('boto3.client')
+        self.mock_boto_client = self.patcher_boto.start()
+        self.mock_boto_client.return_value = MagicMock()
+
+        with patch.object(Processor, 'get_config', return_value={}):
+            self.processor = Processor(test=True)
+
+
+    def tearDown(self):
+        self.patcher_boto.stop()
+        del self.processor
+
+
+    def test_processor_initialization(self):
+        self.assertIsInstance(self.processor, Processor)
+
+
+    def test_call_counts_processed_records(self):
+        result = self.processor({'records': ['a', 'b']})
+
+        self.assertEqual(result['processed'], 2)
+
+
+    def test_call_without_records(self):
+        result = self.processor({})
+
+        self.assertEqual(result['processed'], 0)
+
+
+    def test_no_state_leak_between_invocations(self):
+        """Simulate a warm container: second call must not see first call's state."""
+        self.processor({'records': ['a', 'b', 'c']})
+        result = self.processor({'records': ['d']})
+
+        self.assertEqual(result['processed'], 1)
+{% endif %}
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/cleanup.py
+++ b/examples/cleanup.py
@@ -10,7 +10,7 @@ import sys
 
 from pathlib import Path
 from urllib import request
-from sosw import Processor
+from sosw.app import Processor
 from sosw.components.helpers import recursive_update
 
 

--- a/examples/config_updater.py
+++ b/examples/config_updater.py
@@ -29,7 +29,7 @@ import sys
 
 from pathlib import Path
 from urllib import request
-from sosw import Processor
+from sosw.app import Processor
 from sosw.components.helpers import recursive_update
 
 
@@ -76,7 +76,7 @@ class ConfigUploader(Processor):
                 config_name = entry.path[2:-5]
 
                 # Clean out of extra word separators.
-                config_value = re.sub('\s+', '', Path(entry.path).read_text())
+                config_value = re.sub(r'\s+', '', Path(entry.path).read_text())
 
                 # Substitute your account
                 config_value = config_value.replace('000000000000', self.aws_account)

--- a/examples/layers/sosw/README.md
+++ b/examples/layers/sosw/README.md
@@ -1,0 +1,69 @@
+# sosw Lambda layer
+
+Build and publish an AWS Lambda layer with the `sosw` framework, so your functions ship only
+their own code and import `sosw` (and friends) from the layer.
+
+**Contents of the layer** (python/ directory layout):
+
+- `sosw` (pinned release; `boto3`/`botocore` come along as its dependency — AWS recommends
+  pinning your own copy instead of relying on the runtime-bundled one),
+- default-on extras: [`aws-lambda-powertools`](https://docs.powertools.aws.dev/lambda/python/latest/)
+  (sosw uses its `Logger` automatically when present) and `aws-xray-sdk`. Disable with `--no-extras`.
+
+**Compatible runtimes:** `python3.10`, `python3.11`, `python3.12`, `python3.13`, `python3.14`.
+
+## Build
+
+```bash
+./build.sh                              # sosw==3.0.0 + powertools + xray -> ./sosw-layer.zip
+./build.sh --no-extras                  # only sosw + its dependencies
+./build.sh --sosw-version 3.0.1         # pin another release
+./build.sh --use-local                  # pre-release: install sosw from this repo checkout
+./build.sh --output /tmp/sosw-layer.zip
+```
+
+Build with the same Python minor version as your Lambda runtime when possible
+(override the interpreter with `PYTHON=python3.13 ./build.sh`). All bundled packages are
+pure Python, so the zip is architecture- and platform-independent.
+
+## Deploy
+
+```bash
+./deploy.sh                             # publishes ./sosw-layer.zip + updates SSM pointer
+./deploy.sh --zip /tmp/sosw-layer.zip --region us-east-1 --profile my-profile
+./deploy.sh --dry-run                   # print the AWS commands without executing
+```
+
+`deploy.sh` publishes a new layer version and writes its ARN to the SSM parameter
+**`lambda-layer-sosw-latest`**. It is safe to re-run: when the latest published layer version
+already has the same content hash (`CodeSha256`) as the local zip, publishing is skipped and only
+the SSM pointer is reconciled. Region and credentials come from the standard AWS environment
+(`AWS_PROFILE`, `AWS_REGION`, ...) unless overridden with `--region` / `--profile`.
+
+Required permissions: `lambda:PublishLayerVersion`, `lambda:ListLayerVersions`,
+`lambda:GetLayerVersion`, `ssm:GetParameter`, `ssm:PutParameter`.
+
+## Consume the layer in a SAM template
+
+Resolve the ARN from SSM at deploy time — templates never hardcode layer versions:
+
+```yaml
+Parameters:
+  LambdaLayerSoswLatestArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: lambda-layer-sosw-latest
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.lambda_handler
+      Runtime: python3.13
+      Layers:
+        - !Ref LambdaLayerSoswLatestArn
+```
+
+Already-deployed functions keep the layer version they were deployed with; they pick up the new
+ARN on their next `sam deploy`. The cookiecutter template in
+[`cookiecutter/`](../../../cookiecutter/) scaffolds a project wired to this parameter.

--- a/examples/layers/sosw/build.sh
+++ b/examples/layers/sosw/build.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Build the `sosw` AWS Lambda layer zip (python/ directory layout).
+#
+# By default installs the pinned release `sosw==3.0.0` from PyPI together with the
+# default-on extras (aws-lambda-powertools, aws-xray-sdk). For pre-release builds
+# use --use-local to install sosw from this repository checkout instead.
+#
+# Usage:
+#   ./build.sh [--use-local] [--no-extras] [--sosw-version X.Y.Z] [--output FILE]
+#
+# Options:
+#   --use-local           Install sosw from the repository this script lives in (pre-release builds).
+#   --no-extras           Do not bundle aws-lambda-powertools and aws-xray-sdk.
+#   --sosw-version X.Y.Z  Pin a different sosw release (default: 3.0.0). Ignored with --use-local.
+#   --output FILE         Path of the resulting zip (default: ./sosw-layer.zip).
+#
+# Environment:
+#   PYTHON                Python interpreter to build with (default: python3). Its pip is used,
+#                         so pick the same minor version as your Lambda runtime when possible.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+PYTHON="${PYTHON:-python3}"
+SOSW_VERSION='3.0.0'
+USE_LOCAL='false'
+WITH_EXTRAS='true'
+OUTPUT="$(pwd)/sosw-layer.zip"
+
+usage() {
+    sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --use-local)    USE_LOCAL='true' ;;
+        --no-extras)    WITH_EXTRAS='false' ;;
+        --sosw-version) SOSW_VERSION="${2:?--sosw-version requires a value}"; shift ;;
+        --output)       OUTPUT="${2:?--output requires a value}"; shift ;;
+        -h|--help)      usage; exit 0 ;;
+        *)              echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
+
+case "${OUTPUT}" in
+    /*) : ;;
+    *)  OUTPUT="$(pwd)/${OUTPUT}" ;;
+esac
+
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sosw-layer-build.XXXXXX")"
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+if [ "${USE_LOCAL}" = 'true' ]; then
+    SOSW_REQUIREMENT="${REPO_ROOT}"
+    echo "Building sosw layer from local sources: ${REPO_ROOT}"
+else
+    SOSW_REQUIREMENT="sosw==${SOSW_VERSION}"
+    echo "Building sosw layer from PyPI: ${SOSW_REQUIREMENT}"
+fi
+
+PACKAGES=("${SOSW_REQUIREMENT}")
+if [ "${WITH_EXTRAS}" = 'true' ]; then
+    PACKAGES+=('aws-lambda-powertools' 'aws-xray-sdk')
+    echo "Including default extras: aws-lambda-powertools, aws-xray-sdk"
+else
+    echo "Skipping extras (--no-extras)"
+fi
+
+"${PYTHON}" -m pip install --quiet --target "${BUILD_DIR}/python" "${PACKAGES[@]}"
+
+# Trim bytecode caches - dead weight in a layer.
+find "${BUILD_DIR}/python" -type d -name '__pycache__' -prune -exec rm -rf {} +
+
+mkdir -p "$(dirname "${OUTPUT}")"
+rm -f "${OUTPUT}"
+(cd "${BUILD_DIR}" && "${PYTHON}" -m zipfile -c "${OUTPUT}" python)
+
+SIZE="$(du -h "${OUTPUT}" | cut -f1 | tr -d '[:space:]')"
+echo "Layer zip built: ${OUTPUT} (${SIZE})"
+echo "Publish it with: ./deploy.sh --zip ${OUTPUT}"

--- a/examples/layers/sosw/deploy.sh
+++ b/examples/layers/sosw/deploy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Publish the `sosw` Lambda layer zip and point the SSM parameter at the new version.
+#
+# Publishes a new layer version with `aws lambda publish-layer-version` and updates the
+# SSM parameter (default `lambda-layer-sosw-latest`) that SAM templates consume via
+# `AWS::SSM::Parameter::Value<String>`. Idempotent: when the latest published layer
+# version already has the same content hash as the local zip, publishing is skipped and
+# only the SSM pointer is reconciled.
+#
+# Usage:
+#   ./deploy.sh [--zip FILE] [--layer-name NAME] [--ssm-parameter NAME]
+#               [--region REGION] [--profile PROFILE] [--dry-run]
+#
+# Options:
+#   --zip FILE            Layer zip built by build.sh (default: ./sosw-layer.zip).
+#   --layer-name NAME     Lambda layer name (default: sosw).
+#   --ssm-parameter NAME  SSM parameter holding the latest layer ARN (default: lambda-layer-sosw-latest).
+#   --region REGION       AWS region (default: from AWS_REGION/AWS_DEFAULT_REGION or the profile).
+#   --profile PROFILE     AWS CLI profile (default: from AWS_PROFILE or the default credentials chain).
+#   --dry-run             Print the AWS commands without executing anything.
+
+set -euo pipefail
+
+ZIP_FILE='sosw-layer.zip'
+LAYER_NAME='sosw'
+SSM_PARAMETER='lambda-layer-sosw-latest'
+DRY_RUN='false'
+AWS_ARGS=()
+
+COMPATIBLE_RUNTIMES='python3.10 python3.11 python3.12 python3.13 python3.14'
+
+usage() {
+    sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --zip)           ZIP_FILE="${2:?--zip requires a value}"; shift ;;
+        --layer-name)    LAYER_NAME="${2:?--layer-name requires a value}"; shift ;;
+        --ssm-parameter) SSM_PARAMETER="${2:?--ssm-parameter requires a value}"; shift ;;
+        --region)        AWS_ARGS+=('--region' "${2:?--region requires a value}"); shift ;;
+        --profile)       AWS_ARGS+=('--profile' "${2:?--profile requires a value}"); shift ;;
+        --dry-run)       DRY_RUN='true' ;;
+        -h|--help)       usage; exit 0 ;;
+        *)               echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    esac
+    shift
+done
+
+# Portable expansion of a possibly-empty array under `set -u` (bash 3.2 compatible).
+aws_cli() {
+    aws ${AWS_ARGS[@]+"${AWS_ARGS[@]}"} "$@"
+}
+
+DESCRIPTION="sosw framework layer built from $(basename "${ZIP_FILE}") on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [ "${DRY_RUN}" = 'true' ]; then
+    echo "[dry-run] Would run:"
+    echo "[dry-run]   aws ${AWS_ARGS[*]-} lambda publish-layer-version --layer-name ${LAYER_NAME} \\"
+    echo "[dry-run]       --description '${DESCRIPTION}' --license-info MIT \\"
+    echo "[dry-run]       --zip-file fileb://${ZIP_FILE} --compatible-runtimes ${COMPATIBLE_RUNTIMES}"
+    echo "[dry-run]   aws ${AWS_ARGS[*]-} ssm put-parameter --name ${SSM_PARAMETER} --type String \\"
+    echo "[dry-run]       --value <LayerVersionArn> --overwrite"
+    echo "[dry-run] (publishing is skipped when the latest layer version already has the same CodeSha256)"
+    exit 0
+fi
+
+if [ ! -f "${ZIP_FILE}" ]; then
+    echo "Layer zip not found: ${ZIP_FILE}. Build it first: ./build.sh --output ${ZIP_FILE}" >&2
+    exit 1
+fi
+
+LOCAL_SHA="$(openssl dgst -sha256 -binary "${ZIP_FILE}" | base64)"
+
+LATEST_VERSION="$(aws_cli lambda list-layer-versions --layer-name "${LAYER_NAME}" --max-items 1 \
+                  --query 'LayerVersions[0].Version' --output text)"
+
+LAYER_ARN=''
+if [ "${LATEST_VERSION}" != 'None' ] && [ -n "${LATEST_VERSION}" ]; then
+    REMOTE_SHA="$(aws_cli lambda get-layer-version --layer-name "${LAYER_NAME}" \
+                  --version-number "${LATEST_VERSION}" --query 'Content.CodeSha256' --output text)"
+
+    if [ "${REMOTE_SHA}" = "${LOCAL_SHA}" ]; then
+        LAYER_ARN="$(aws_cli lambda get-layer-version --layer-name "${LAYER_NAME}" \
+                     --version-number "${LATEST_VERSION}" --query 'LayerVersionArn' --output text)"
+        echo "Layer version ${LATEST_VERSION} already has this content (CodeSha256 match). Skipping publish."
+    fi
+fi
+
+if [ -z "${LAYER_ARN}" ]; then
+    # shellcheck disable=SC2086  # COMPATIBLE_RUNTIMES is intentionally word-split.
+    LAYER_ARN="$(aws_cli lambda publish-layer-version \
+                 --layer-name "${LAYER_NAME}" \
+                 --description "${DESCRIPTION}" \
+                 --license-info 'MIT' \
+                 --zip-file "fileb://${ZIP_FILE}" \
+                 --compatible-runtimes ${COMPATIBLE_RUNTIMES} \
+                 --query 'LayerVersionArn' --output text)"
+    echo "Published new layer version: ${LAYER_ARN}"
+fi
+
+CURRENT_POINTER="$(aws_cli ssm get-parameter --name "${SSM_PARAMETER}" \
+                   --query 'Parameter.Value' --output text 2>/dev/null || echo '')"
+
+if [ "${CURRENT_POINTER}" = "${LAYER_ARN}" ]; then
+    echo "SSM parameter ${SSM_PARAMETER} already points at ${LAYER_ARN}. Nothing to do."
+else
+    aws_cli ssm put-parameter --name "${SSM_PARAMETER}" --type 'String' \
+        --value "${LAYER_ARN}" --overwrite > /dev/null
+    echo "SSM parameter ${SSM_PARAMETER} updated: ${LAYER_ARN}"
+fi


### PR DESCRIPTION
Part of the **sosw 3.0.0** release. Spec: `.kiro/specs/hq-692-sosw-3-0-0/` (R10, R11). Delivers #388.

## What
- **AGENTS.md** — the repo's instruction file for AI coding agents (agents.md convention): package map, how to build a Lambda on sosw (Processor / LambdaApi / durable skeletons with real 3.0 wiring), config layering incl. `disable_ddb_config`, exact unit-test mock patterns, the container-reuse regression pattern, debugging playbook, style rules, and repo mechanics (X_Y_Z staging, 100% coverage bar, docs `-W`).
- **cookiecutter/** — quickstart scaffolding: `cookiecutter https://github.com/sosw/sosw --directory cookiecutter`; Processor or LambdaApi variant, Python 3.10–3.14 choice, SAM template with the org's SSM layer-parameter pattern and a no-default `Stage`.
- **examples/layers/sosw/** — `build.sh` (layer zip; aws-lambda-powertools + aws-xray-sdk default-ON, `--no-extras` to disable, `--use-local` for pre-release builds) + `deploy.sh` (`publish-layer-version` for runtimes 3.10–3.14 + `lambda-layer-sosw-latest` SSM pointer; idempotent via CodeSha256; `--dry-run`).
- **examples/** modernized (façade→`sosw.app` imports; the `config_updater.py` raw-regex SyntaxWarning fixed). **.kiro/steering** refreshed.

## Verification
- Both cookiecutter variants generated and unit-tested: plain `4 passed`, api `8 passed` (incl. state-leak + claims-leak regression tests); rendered YAML parses.
- Layer smoke: `--use-local` zip contains sosw 3.0 modules + powertools + xray, `import sosw` works from the extracted `python/` dir in a clean env; `--no-extras` correctly excludes; `deploy.sh --dry-run` prints exact AWS calls, makes none.
- `python -W error::SyntaxWarning -m compileall examples/` clean; unit suite untouched and green (359 passed).

## Note
- `examples/.aws/config` (region-only, no secrets) left in place — it is part of the example fixture, distinct from the removed repo-root one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)