### PR TITLE
3.0.0 release polish: spec ticked, CI on 3.14, docs publishing (OIDC)

### DIFF
--- a/.github/workflows/docs-builder-action.yaml
+++ b/.github/workflows/docs-builder-action.yaml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,68 @@
+# Publishes the documentation to https://docs.sosw.app: builds the Sphinx docs strictly (-W),
+# syncs the result to the docs S3 bucket and invalidates the CloudFront distribution.
+#
+# Runs automatically on every push to master. Can also be dispatched manually: the default
+# dry-run mode builds the docs and only prints the would-be `s3 sync` changes (--dryrun),
+# skipping the CloudFront invalidation.
+#
+# AWS access is OIDC-assumed via aws-actions/configure-aws-credentials — no static keys.
+# Required repository variables:
+#   DOCS_AWS_ROLE_ARN   - IAM role trusted for GitHub OIDC, assumed by this workflow
+#   DOCS_AWS_REGION     - us-west-2
+#   DOCS_BUCKET         - sosw-documentation-926629045956
+#   DOCS_CLOUDFRONT_ID  - E162963MSFBLR9
+
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+        description: 'Build and s3-sync --dryrun only; no invalidation'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
+
+    - name: Build docs
+      run: python -m sphinx -W -a -b html docs sosw-rtd
+
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ vars.DOCS_AWS_ROLE_ARN }}
+        aws-region: ${{ vars.DOCS_AWS_REGION }}
+
+    # Push events and manual dispatches with dry_run=false sync for real; a manual dispatch
+    # with dry_run=true (the default) only prints the would-be changes.
+    - name: Sync docs to S3
+      run: |
+        DRYRUN=$([[ '${{ github.event_name }}' == 'workflow_dispatch' && '${{ inputs.dry_run }}' == 'true' ]] && echo '--dryrun' || echo '')
+        aws s3 sync sosw-rtd/ 's3://${{ vars.DOCS_BUCKET }}/' --delete $DRYRUN
+
+    - name: Invalidate CloudFront cache
+      if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+      run: aws cloudfront create-invalidation --distribution-id '${{ vars.DOCS_CLOUDFRONT_ID }}' --paths '/*'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: '3.14'
 
     - name: Install pypa/build
       run: python3 -m pip install build --user

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install pypa/build
       run: python3 -m pip install build --user

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -1,5 +1,6 @@
-# Runs the sosw unit test suite on every pull request: once per supported Python version,
-# plus a separate coverage job that enforces the minimum line coverage threshold.
+# Runs the sosw unit test suite on every pull request: once per CI-tested Python version
+# (the three latest; the package itself supports 3.10+), plus a separate coverage job that
+# enforces the minimum line coverage threshold.
 
 name: Tests
 
@@ -14,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4
@@ -38,10 +39,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: |

--- a/.kiro/specs/hq-692-sosw-3-0-0/tasks.md
+++ b/.kiro/specs/hq-692-sosw-3-0-0/tasks.md
@@ -2,42 +2,62 @@
 
 Each numbered task = one PR into `3_0_0` unless noted. Requirements references in brackets.
 
-- [ ] 1. CI & repo hygiene (`hq-692-ci-workflows`) [R8, R10-part]
-  - [ ] 1.1 Commit spec (`.kiro/specs/hq-692-sosw-3-0-0/`) and initial `.kiro/steering/` docs
-  - [ ] 1.2 `run-unittests.yml`: 3.10–3.14 matrix + coverage job (`--cov-fail-under`, staged threshold)
-  - [ ] 1.3 `docs-builder-action.yaml`: pip-based, `sphinx-build -W`
-  - [ ] 1.4 `publish-to-test-pypi.yml`: staging-branch pattern `X_Y_Z`, version patch step
-  - [ ] 1.5 README badges → GitHub Actions; remove Travis; drop stray `.aws/config`; gitignore `.claude/`
-- [ ] 2. Deprecations (`hq-692-deprecations`) [R2]
-  - [ ] 2.1 Deprecation helper + warnings in all 10 deprecated classes
-  - [ ] 2.2 `sosw/__init__.py` lazy façade (PEP 562), `siblings.py` import fix
-  - [ ] 2.3 Unit tests: warning emitted once per class, façade lazy, components silent
-- [ ] 3. lambda_api (`hq-692-lambda-api`) [R4]
-  - [ ] 3.1 `ApiError` hierarchy in `components/exceptions.py`
-  - [ ] 3.2 `sosw/lambda_api.py` LambdaApi with router/auth/CORS/encoder/envelope
-  - [ ] 3.3 Full unit test matrix (v1+v2 events, auth paths, errors, CORS, encoder)
-- [ ] 4. Warm start + durable (`hq-692-durable`) [R3, R5]
-  - [ ] 4.1 Extract shared `_make_lambda_handler`; fix `test` precedence; single `reset_stats`; `disable_ddb_config`
-  - [ ] 4.2 `sosw/durable.py` + helpers, import guards
-  - [ ] 4.3 Unit tests incl. fake-SDK injection and no-SDK-leak assertions
-- [ ] 5. Packaging + helpers tidy (`hq-692-packaging`) [R1, R6]
-  - [ ] 5.1 `pyproject.toml` full metadata, version 3.0.0, extras `[durable]`, 3.14 classifier
-  - [ ] 5.2 Pipfile/lock refresh or removal (kill the 15 Dependabot alerts)
-  - [ ] 5.3 `case_insensitive` for `recursive_matches_extract` (PR #379, credited); scheduler raw-string fix
-- [ ] 6. Coverage 100% (`hq-692-coverage`) [R7]
-  - [ ] 6.1 Register orphan tests; retire duplicate legacy test_config
-  - [ ] 6.2 Per-module test authoring to 100% (incl. decorators.py from 0%)
-  - [ ] 6.3 Powertools import-guard branch coverage via module reload technique
-  - [ ] 6.4 Raise CI gate to `--cov-fail-under=100`
-- [ ] 7. Docs rebuild (`hq-692-docs`) [R9]
-  - [ ] 7.1 Theme + structure + quickstart + concepts + component guides
-  - [ ] 7.2 lambda_api + durable guides, tutorials refresh, migration_3_0 page
-  - [ ] 7.3 Deprecated section banner-marked; all examples on 3.0 API
-- [ ] 8. Agent docs & bootstrap tooling (`hq-692-agent-docs`) [R10, R11]
-  - [ ] 8.1 `AGENTS.md` (closes #388) + steering refinement
-  - [ ] 8.2 Cookiecutter template + docs
-  - [ ] 8.3 Layer example with autobuild/autodeploy scripts (powertools/xray default-on)
-- [ ] 9. GitHub triage (no PR) [R12]
-  - [ ] 9.1 Triage comments on all open issues/PRs as bender-sosw; close obsolete
-  - [ ] 9.2 File new improvement issues
-- [ ] 10. Release PR `3_0_0 → master` — open, changelog, DO NOT merge (human gate)
+- [x] 1. CI & repo hygiene (`hq-692-ci-workflows`) [R8, R10-part]
+  - [x] 1.1 Commit spec (`.kiro/specs/hq-692-sosw-3-0-0/`) and initial `.kiro/steering/` docs
+  - [x] 1.2 `run-unittests.yml`: 3.10–3.14 matrix + coverage job (`--cov-fail-under`, staged threshold)
+  - [x] 1.3 `docs-builder-action.yaml`: pip-based, `sphinx-build -W`
+  - [x] 1.4 `publish-to-test-pypi.yml`: staging-branch pattern `X_Y_Z`, version patch step
+  - [x] 1.5 README badges → GitHub Actions; remove Travis; drop stray `.aws/config`; gitignore `.claude/`
+- [x] 2. Deprecations (`hq-692-deprecations`) [R2]
+  - [x] 2.1 Deprecation helper + warnings in all 10 deprecated classes
+  - [x] 2.2 `sosw/__init__.py` lazy façade (PEP 562), `siblings.py` import fix
+  - [x] 2.3 Unit tests: warning emitted once per class, façade lazy, components silent
+- [x] 3. lambda_api (`hq-692-lambda-api`) [R4]
+  - [x] 3.1 `ApiError` hierarchy in `components/exceptions.py`
+  - [x] 3.2 `sosw/lambda_api.py` LambdaApi with router/auth/CORS/encoder/envelope
+  - [x] 3.3 Full unit test matrix (v1+v2 events, auth paths, errors, CORS, encoder)
+- [x] 4. Warm start + durable (`hq-692-durable`) [R3, R5]
+  - [x] 4.1 Extract shared `_make_lambda_handler`; fix `test` precedence; single `reset_stats`; `disable_ddb_config`
+  - [x] 4.2 `sosw/durable.py` + helpers, import guards
+  - [x] 4.3 Unit tests incl. fake-SDK injection and no-SDK-leak assertions
+- [x] 5. Packaging + helpers tidy (`hq-692-packaging`) [R1, R6]
+  - [x] 5.1 `pyproject.toml` full metadata, version 3.0.0, extras `[durable]`, 3.14 classifier
+  - [x] 5.2 Pipfile/lock refresh or removal (kill the 15 Dependabot alerts)
+  - [x] 5.3 `case_insensitive` for `recursive_matches_extract` (PR #379, credited); scheduler raw-string fix
+- [x] 6. Coverage 100% (`hq-692-coverage`) [R7]
+  - [x] 6.1 Register orphan tests; retire duplicate legacy test_config
+  - [x] 6.2 Per-module test authoring to 100% (incl. decorators.py from 0%)
+  - [x] 6.3 Powertools import-guard branch coverage via module reload technique
+  - [x] 6.4 Raise CI gate to `--cov-fail-under=100`
+- [x] 7. Docs rebuild (`hq-692-docs`) [R9]
+  - [x] 7.1 Theme + structure + quickstart + concepts + component guides
+  - [x] 7.2 lambda_api + durable guides, tutorials refresh, migration_3_0 page
+  - [x] 7.3 Deprecated section banner-marked; all examples on 3.0 API
+- [x] 8. Agent docs & bootstrap tooling (`hq-692-agent-docs`) [R10, R11]
+  - [x] 8.1 `AGENTS.md` (closes #388) + steering refinement
+  - [x] 8.2 Cookiecutter template + docs
+  - [x] 8.3 Layer example with autobuild/autodeploy scripts (powertools/xray default-on)
+- [x] 9. GitHub triage (no PR) [R12]
+  - [x] 9.1 Triage comments on all open issues/PRs as bender-sosw; close obsolete
+  - [x] 9.2 File new improvement issues
+- [x] 10. Release PR `3_0_0 → master` — open, changelog, DO NOT merge (human gate)
+
+## Delivery map
+
+All PRs merged into `3_0_0`, except the task 10 release PR which is open pending the human merge gate.
+
+| Task | Delivered by |
+|------|--------------|
+| 1    | PR #390 |
+| 2    | PR #392 |
+| 3    | PR #393 |
+| 4    | PR #394 |
+| 5    | PR #391 |
+| 6    | PR #404 |
+| 7    | PR #403 |
+| 8    | PR #402 |
+| 9    | Triage comments on all open issues/PRs + new issues #395–#401, #405–#406 (no PR) |
+| 10   | PR #407 (`3_0_0 → master`, open — human merge gate) |
+
+Post-review polish (release-PR review): CI now runs on the three latest Pythons (3.12–3.14 matrix)
+with 3.14 as the default runtime for all CI/CD jobs; the package itself still supports 3.10+.

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -31,5 +31,5 @@ Processor, components, helpers — is the product.
 
 - 100% unit test line coverage, enforced in CI. Unit suite is network-free and fast (seconds).
 - Zero mandatory dependencies beyond `boto3`.
-- Python 3.10–3.14.
+- Python 3.10–3.14 supported; CI-tested on the three latest (3.12–3.14).
 - Docs at https://docs.sosw.app must build warning-free.

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -33,8 +33,9 @@
 
 ## CI/CD
 
-- GitHub Workflows only (Travis is gone): Tests matrix 3.10–3.14 + coverage job (100%), Docs build
-  (Sphinx `-W`), TestPyPI RC publish on staging branches (`X_Y_Z`), PyPI publish on push to `master`.
+- GitHub Workflows only (Travis is gone): Tests matrix 3.12–3.14 (the three latest; the package
+  supports 3.10+) + coverage job (100%, on 3.14), Docs build (Sphinx `-W`), TestPyPI RC publish on
+  staging branches (`X_Y_Z`), PyPI publish on push to `master`. Default CI runtime: Python 3.14.
 - Staging-branch flow: feature branches → PR into the current `X_Y_Z` staging branch → release PR
   `X_Y_Z → master`. Merging to master publishes to PyPI.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,9 +321,10 @@ PRs violating these get bounced in review:
 - Branch flow: feature branch → PR into the current **`X_Y_Z` staging branch** (e.g. `3_0_1`), not
   into `master`. Pushes to staging branches publish release candidates to TestPyPI; merging the
   release PR `X_Y_Z → master` publishes to PyPI. Never merge to `master` yourself.
-- CI gates on PRs: unit suite on Python 3.10–3.14, **100% coverage**, and a Sphinx docs build with
-  `-W` (any docs warning fails the build — update `docs/` in the same PR when you change public
-  API or docstrings referenced there).
+- CI gates on PRs: unit suite on Python 3.12–3.14 (the three latest; the package supports 3.10+),
+  **100% coverage** (job runs on 3.14), and a Sphinx docs build with `-W` (any docs warning fails
+  the build — update `docs/` in the same PR when you change public API or docstrings referenced
+  there).
 - Deprecated modules: bugfixes only, no new features, nothing removed before 4.0.
 - `examples/`, `cookiecutter/`, and `AGENTS.md` must track the public API: if your change alters
   signatures or config conventions shown there, update them in the same PR.

--- a/cookiecutter/README.md
+++ b/cookiecutter/README.md
@@ -23,7 +23,7 @@ Answer the prompts (defaults in parentheses):
 | `project_slug` | Python-friendly project directory name (`my_sosw_lambda`) |
 | `function_name` | Lambda `FunctionName` and CloudFormation stack name, kebab-case (derived from the slug) |
 | `description` | One-line description used in the template and docstrings |
-| `python_version` | Lambda runtime version (`3.13`; also 3.10 / 3.11 / 3.12 / 3.14) |
+| `python_version` | Lambda runtime version (`3.14`; also 3.10 / 3.11 / 3.12 / 3.13) |
 | `use_lambda_api` | `yes` scaffolds an HTTP API Lambda on `sosw.lambda_api.LambdaApi` (declarative routes, auth, JSON envelopes); `no` (default) scaffolds a plain event Processor |
 | `aws_region` | Region written to `samconfig.toml` |
 

--- a/cookiecutter/cookiecutter.json
+++ b/cookiecutter/cookiecutter.json
@@ -2,7 +2,7 @@
     "project_slug":      "my_sosw_lambda",
     "function_name":     "{{ cookiecutter.project_slug | replace('_', '-') }}",
     "description":       "AWS Lambda function built on the sosw framework.",
-    "python_version":    ["3.13", "3.10", "3.11", "3.12", "3.14"],
+    "python_version":    ["3.14", "3.10", "3.11", "3.12", "3.13"],
     "use_lambda_api":    ["no", "yes"],
     "aws_region":        "us-east-1",
     "_jinja2_env_vars":  {

--- a/docs/_static/images/coverage.svg
+++ b/docs/_static/images/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">82%</text>
-        <text x="80" y="14">82%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
+        <text x="80" y="14">100%</text>
     </g>
 </svg>

--- a/docs/contribution/index.rst
+++ b/docs/contribution/index.rst
@@ -111,12 +111,16 @@ Continuous integration
 
 GitHub Workflows run on every pull request:
 
-- **Tests** (``run-unittests.yml``) — the unit suite on a Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14
-  matrix, plus a coverage job enforcing the threshold.
+- **Tests** (``run-unittests.yml``) — the unit suite on a Python 3.12 / 3.13 / 3.14 matrix (the
+  three latest versions; the package itself supports 3.10+), plus a coverage job enforcing the
+  threshold on Python 3.14.
 - **Docs** (``docs-builder-action.yaml``) — strict Sphinx build; **any warning fails the build**.
 - **TestPyPI** (``publish-to-test-pypi.yml``) — publishes release candidates from ``X_Y_Z``
   staging branches.
 - **PyPI** (``publish-to-pypi.yml``) — publishes from ``master``.
+- **Publish Docs** (``publish-docs.yml``) — publishes the built docs to https://docs.sosw.app
+  automatically on every push to ``master`` (OIDC-assumed AWS role, no static keys); a manual
+  dispatch offers a dry-run mode.
 
 
 Building the docs


### PR DESCRIPTION
Addresses Nik's release-review feedback on #407.

## What
1. **Spec closed out**: `.kiro/specs/hq-692-sosw-3-0-0/tasks.md` — all 39 checkboxes ticked + a delivery map (task → merged PR).
2. **CI on Python 3.14, three-latest matrix**: default runtime `3.14` in ALL workflows (tests/coverage/docs/both publishes); unit matrix narrowed to **3.12 / 3.13 / 3.14**. Package compatibility statements unchanged (`requires-python >= 3.10`, classifiers 3.10–3.14 — CI-tested on the three latest). Docs/steering/AGENTS.md updated to match; cookiecutter default runtime → 3.14.
3. **Coverage badge**: `docs/_static/images/coverage.svg` regenerated from a real run — was a stale 82%, now 100%.
4. **NEW `publish-docs.yml`**: on master push (and manual dispatch with default-true `dry_run`): sphinx `-W` build → `aws s3 sync --delete` to the docs bucket → CloudFront invalidation (skipped in dry-run). **AWS auth via OIDC-assumed role — no static keys.** Reads 4 repo variables (`DOCS_AWS_ROLE_ARN`, `DOCS_AWS_REGION`, `DOCS_BUCKET`, `DOCS_CLOUDFRONT_ID`); the IAM role + variables are being provisioned in-session with Nik.

## Verification
- All 5 workflow YAMLs parse; sync-flag logic simulated under `bash -e` for all three event shapes (push → real sync; dispatch default → `--dryrun`; dispatch dry_run=false → real sync + invalidation).
- Suite on Python 3.14: 604 passed, TOTAL **100.00%**. Docs `-W` clean after all edits.
- Cookiecutter regenerated with the new default: `Runtime: python3.14`, generated tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)