### PR TITLE
Docs fixes: furo contents error box + copyright 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (C) 2025  sosw core contributors <info@sosw.app>:
+Copyright (C) 2026  sosw core contributors <info@sosw.app>:
     Nikolay Grishchenko
     Sophie Fogel
     Gil Halperin

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (C) 2025  sosw core contributors <info@sosw.app>:
+Copyright (C) 2026  sosw core contributors <info@sosw.app>:
     Nikolay Grishchenko
     Sophie Fogel
     Gil Halperin

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This document has been placed in the public domain.
     sosw - a framework for bootstrapping AWS Lambda functions
     
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>:
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>:
         Nikolay Grishchenko
         Sophie Fogel
         Gil Halperin

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # -- Project information ---------------------------------------------------
 
 project = 'sosw'
-copyright = '2025, sosw core contributors'
+copyright = '2026, sosw core contributors'
 author = 'Nikolay Grishchenko'
 
 try:

--- a/docs/contribution/index.rst
+++ b/docs/contribution/index.rst
@@ -5,8 +5,6 @@ Contribution Guidelines
 =======================
 
 
-..  contents::
-
 ..  toctree::
 
     Documentation Convention <convention>

--- a/sosw/__init__.py
+++ b/sosw/__init__.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/app.py
+++ b/sosw/app.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/benchmark.py
+++ b/sosw/components/benchmark.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/config.py
+++ b/sosw/components/config.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/decorators.py
+++ b/sosw/components/decorators.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/dynamo_db.py
+++ b/sosw/components/dynamo_db.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/helpers.py
+++ b/sosw/components/helpers.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/siblings.py
+++ b/sosw/components/siblings.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/sigv4.py
+++ b/sosw/components/sigv4.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/components/sns.py
+++ b/sosw/components/sns.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/durable.py
+++ b/sosw/durable.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/sosw/lambda_api.py
+++ b/sosw/lambda_api.py
@@ -5,7 +5,7 @@
     sosw - a framework for bootstrapping AWS Lambda functions
 
     The MIT License (MIT)
-    Copyright (C) 2025  sosw core contributors <info@sosw.app>
+    Copyright (C) 2026  sosw core contributors <info@sosw.app>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Two fixes from Nik's docs introspection:

1. **Furo error box on Contribution Guidelines**: the page carried a `.. contents::` directive, which furo renders as an in-page ERROR admonition (without failing the `-W` build — it's an HTML-level complaint). Removed; furo's own 'On this page' sidebar covers it. Built-HTML sweep confirms zero error boxes remain (the lone grep hit is the search page's CSS-class boilerplate).
2. **Copyright 2025 → 2026** in LICENSE, NOTICE, the README license excerpt, `docs/conf.py` and all 12 module license headers. The `previous/0.7.51` archive is untouched (verbatim historical artifact).

Verification: suite 390 passed / TOTAL 100.00%; `sphinx -W -a` clean; footer renders '2026, sosw core contributors'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)