### PR TITLE
Fix lambda handler crash for list payloads in test mode

### DIFF
--- a/sosw/app.py
+++ b/sosw/app.py
@@ -534,7 +534,12 @@ def get_lambda_handler(processor_class, global_vars=None, custom_config=None):
                     __name__, context)
         logger.info(event)
 
-        test = event.get('test') or True if os.environ.get('STAGE') in ['test', 'autotest'] else False
+        # `event` is not guaranteed to be a dict: a top-level JSON list is a valid Lambda payload.
+        # Guard the .get() so a non-dict payload does not raise AttributeError in test/autotest stages.
+        if os.environ.get('STAGE') in ['test', 'autotest']:
+            test = (event.get('test') if isinstance(event, dict) else None) or True
+        else:
+            test = False
 
         global_vars.lambda_context = context
 

--- a/sosw/test/unit/test_app.py
+++ b/sosw/test/unit/test_app.py
@@ -138,6 +138,49 @@ class app_UnitTestCase(unittest.TestCase):
             self.assertEqual(global_vars.processor.stats['total_calls_register_clients'], 1)
 
 
+    def test_lambda_handler__list_payload_does_not_crash(self):
+        """
+        Regression for #286: a top-level JSON list is a valid Lambda payload.
+        Under STAGE=test/autotest the handler calls event.get('test'); a list has no .get(),
+        which previously raised AttributeError. The handler must not crash on a non-dict event.
+        """
+
+        class ListTolerantChild(Processor):
+            # Processor that accepts any event type (does not assume dict), so this test
+            # isolates the lambda_handler guard rather than the user's processor logic.
+            def __call__(self, event):
+                super().__call__(event)
+                return 'ok'
+
+        mock_context = MagicMock()
+        mock_context.invoked_function_arn = 'arn:aws:lambda:us-east-1:123456789012:function:example:42'
+
+        for stage in ('test', 'autotest'):
+            os.environ['STAGE'] = stage
+            global_vars = LambdaGlobals()
+            global_vars.processor = None
+            lambda_handler = get_lambda_handler(ListTolerantChild, global_vars, self.TEST_CONFIG)
+            try:
+                result = lambda_handler(event=[], context=mock_context)
+            except AttributeError as e:
+                self.fail(f"lambda_handler crashed on list payload in STAGE={stage}: {e}")
+            self.assertEqual(result, 'ok')
+
+        os.environ['STAGE'] = 'test'
+
+
+    def test_lambda_handler__dict_behavior_unchanged(self):
+        """#286 guard must not change existing dict-event behavior."""
+        mock_context = MagicMock()
+        mock_context.invoked_function_arn = 'arn:aws:lambda:us-east-1:123456789012:function:example:42'
+
+        global_vars = LambdaGlobals()
+        global_vars.processor = None
+        lambda_handler = get_lambda_handler(self.Child, global_vars, self.TEST_CONFIG)
+        result = lambda_handler(event={'k': 'success'}, context=mock_context)
+        self.assertEqual(result, 'success')
+
+
     def test_property_account__initialized_from_context(self):
         mock_context = MagicMock()
         mock_context.invoked_function_arn = 'arn:aws:lambda:us-east-1:123456789000:function:example:42'


### PR DESCRIPTION
Closes #286.

Fix an AttributeError when the Lambda handler receives a non-dict event, such as a JSON list.

The logging_level lookup was already guarded, but the test-mode check still called event.get('test') directly. This could crash in STAGE=test / STAGE=autotest when the Lambda event is a list.

Changes:
- rewrite the test-mode check as an explicit if/else
- guard event.get('test') with isinstance(event, dict)
- add unit coverage for list payloads in test/autotest stages
- add unit coverage confirming dict-event behavior is unchanged
- keep processor invocation semantics untouched

Test:
```
python -m pytest sosw/test/suite_unit.py
```

Note:
The full suite still has 10 unrelated pre-existing failures in this local environment; the same failures appear on clean master. This PR adds 2 passing tests and introduces 0 new failures.