### PR TITLE
Adopt PyPI Trusted Publishing (OIDC) for both publish workflows (#399)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,6 +9,21 @@ jobs:
     name: Build and publish distribution
     runs-on: ubuntu-latest
 
+    # Trusted Publishing (OIDC, GitHub issue #399): PyPI trusts this exact
+    # repo + workflow file + environment instead of a long-lived API token.
+    # Requires a one-time Trusted Publisher registration on pypi.org for the
+    # `sosw` project (owner: sosw, repo: sosw, workflow: publish-to-pypi.yml,
+    # environment: pypi) — human-only step.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sosw
+
+    permissions:
+      # Mandatory for OIDC Trusted Publishing.
+      id-token: write
+      # An explicit permissions block resets the defaults, so restore checkout access.
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
 
@@ -27,5 +42,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/heads/master')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -21,6 +21,22 @@ jobs:
     name: Build and publish RC distribution
     runs-on: ubuntu-latest
 
+    # Trusted Publishing (OIDC, GitHub issue #399): TestPyPI trusts this exact
+    # repo + workflow file + environment instead of a long-lived API token.
+    # Requires a one-time Trusted Publisher registration on test.pypi.org for the
+    # `sosw` project (owner: sosw, repo: sosw, workflow: publish-to-test-pypi.yml,
+    # environment: testpypi) — human-only step. Also unblocks the 2026-07-04
+    # RC-publishing failure (test.pypi `ngr` account lacked 2FA for token auth).
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/sosw
+
+    permissions:
+      # Mandatory for OIDC Trusted Publishing.
+      id-token: write
+      # An explicit permissions block resets the defaults, so restore checkout access.
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
 
@@ -75,5 +91,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Adopts **PyPI Trusted Publishing (OIDC)** for both publish workflows, per #399 — no long-lived API tokens in repo secrets anymore. Targets the staging branch `3_0_0` so it rides into `master` with the release PR #407.

## Changes

- **`.github/workflows/publish-to-pypi.yml`** (release publish on `master` push): drops `password: ${{ secrets.PYPI_TOKEN }}`; adds `environment: pypi` and `permissions: id-token: write` (+ explicit `contents: read`, since an explicit permissions block resets defaults). `pypa/gh-action-pypi-publish@release/v1` auto-detects OIDC when no token is passed.
- **`.github/workflows/publish-to-test-pypi.yml`** (RC publish on `X_Y_Z` staging-branch push): drops `password: ${{ secrets.TEST_PYPI_TOKEN }}`; adds `environment: testpypi` and the same permissions block; keeps `skip-existing`, `repository-url`, and the RC timestamp version patch unchanged.

This also sidesteps the 2026-07-04 TestPyPI RC-publish blocker (the test.pypi `ngr` account lacking 2FA for token auth) — OIDC needs no account token at publish time.

## ⚠️ Human-only prerequisite: register the Trusted Publishers (Nik)

Publishing will FAIL until these two one-time registrations are done by a project owner. Exact values to enter:

### 1. pypi.org — https://pypi.org/manage/project/sosw/settings/publishing/
Add a new **GitHub** trusted publisher for project `sosw`:

| Field | Value |
|---|---|
| Owner | `sosw` |
| Repository name | `sosw` |
| Workflow name | `publish-to-pypi.yml` |
| Environment name | `pypi` |

### 2. test.pypi.org — https://test.pypi.org/manage/project/sosw/settings/publishing/
Add a new **GitHub** trusted publisher for project `sosw`:

| Field | Value |
|---|---|
| Owner | `sosw` |
| Repository name | `sosw` |
| Workflow name | `publish-to-test-pypi.yml` |
| Environment name | `testpypi` |

Notes:
- The environment names are **case-sensitive** and must match exactly (`pypi` / `testpypi`). GitHub creates the environments automatically on first workflow run; optionally add protection rules on them later (Settings → Environments).
- After both registrations are verified working, the now-unused `PYPI_TOKEN` / `TEST_PYPI_TOKEN` repo secrets can be deleted.
- The optional-dependency-extras half of #399 is NOT in this PR — workflows only.

## Merge order (Nik-gated, nothing merged by agents)
1. Register both Trusted Publishers (above).
2. Merge this PR into `3_0_0` — the resulting staging-branch push exercises the TestPyPI OIDC path end-to-end as a live smoke test.
3. Merge release PR #407 (`3_0_0` → `master`) — publishes 3.0.0 to PyPI via OIDC.

Refs #399. Trail: HQ-692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
