### PR TITLE
HQ-875: commercial-support / Hire-us CTAs in README + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **sosw** is a set of serverless tools for orchestrating asynchronous invocations of AWS Lambda Functions (Workers).
 
+*Built and maintained by [SOSW LTD](https://sosw.app?utm_source=github&utm_medium=readme&utm_campaign=sosw-oss) — we design AI-native serverless systems for production. [Enterprise support & consulting →](https://sosw.app?utm_source=github&utm_medium=readme&utm_campaign=sosw-oss)*
+
 ---
 
 ## Documentation
@@ -22,6 +24,14 @@
 
 ## Installation
 See the [Installation Guidelines](https://docs.sosw.app/installation.html) in the Documentation.
+
+## Commercial support
+
+sosw is open source (MIT) and built by [SOSW LTD](https://sosw.app?utm_source=github&utm_medium=readme&utm_campaign=sosw-oss), the team that runs this pattern in production every day.
+
+If your company is putting serverless Lambda systems into production and wants help — an architecture review, production hardening, a custom Lambda platform, or retained support — **[hire us](https://sosw.app?utm_source=github&utm_medium=readme&utm_campaign=sosw-oss)**.
+
+We don't sell hype. We build systems that work.
 
 ## Development
 ### Getting Started

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,13 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+# One-line commercial-support footer appended to every documentation page (HQ-875).
+rst_epilog = """
+----
+
+Running this in production? `SOSW LTD <https://sosw.app?utm_source=github&utm_medium=docs&utm_campaign=sosw-oss>`__ offers commercial support — see :doc:`Commercial Support </support>`.
+"""
+
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,8 @@ Essential components of **`sosw`** orchestration are implemented as AWS Lambda f
 
 	contribution/index
 
+	support
+
 
 Indices and tables
 ==================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -304,3 +304,9 @@ the ``Orchestrator`` and ``Scavenger`` every minute.
         --targets \
             "Id"="1","Arn"="arn:aws:lambda:us-west-2:$ACCOUNT:function:sosw_orchestrator" \
             "Id"="2","Arn"="arn:aws:lambda:us-west-2:$ACCOUNT:function:sosw_scavenger"
+
+
+..  note::
+
+    Putting ``sosw`` into production? SOSW LTD offers commercial support and
+    production hardening — see :doc:`support`.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -48,4 +48,9 @@ Useful tools
 ------------
 Create a sosw Lambda Layer for faster mounting: :ref:`SOSW Layer`
 
+..  note::
+
+    Running ``sosw`` in production? SOSW LTD offers commercial support and
+    consulting — see :doc:`support`.
+
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,0 +1,21 @@
+.. title:: Commercial Support & Enterprise
+
+===================================
+Commercial Support & Enterprise
+===================================
+
+``sosw`` is open source (MIT) and built by
+`SOSW LTD <https://sosw.app?utm_source=github&utm_medium=docs&utm_campaign=sosw-oss>`__,
+the team that runs this pattern in production every day.
+
+If your company is putting serverless Lambda systems into production and wants
+help, we offer commercial engagements:
+
+- **Architecture review** — a focused audit of your serverless / Lambda design.
+- **Production hardening** — idempotency, retries, observability, cost control.
+- **Custom Lambda platform** — a tailored ``sosw``-based foundation for your team.
+- **Retained support** — ongoing help from the people who wrote the framework.
+
+We don't sell hype. We build systems that work.
+
+`Hire us → <https://sosw.app?utm_source=github&utm_medium=docs&utm_campaign=sosw-oss>`__


### PR DESCRIPTION
## HQ-875 — Commercial-support / "Hire us" CTAs in README + docs

Implements the immediate-value part of the **HQ-870** lead-magnet plan (§1): tasteful, anti-hype "Hire us / Enterprise support" CTAs so `sosw` works as an OSS lead magnet. Copy is verbatim from the HQ-870 plan (execution-only).

### What changed (docs + README only — no code, no version bump)
- **README.md**
  - one compact line directly under the tagline (SOSW LTD + Enterprise-support link)
  - a `## Commercial support` section placed before `## Development`
- **docs/** (Sphinx, `sphinx_rtd_theme`)
  - new **`docs/support.rst`** — *Commercial Support & Enterprise* — added as a top-level `toctree` entry so it appears in the persistent left nav on every page
  - a one-line support footer on **every** page via `rst_epilog` in `conf.py`
  - a `.. note::` at the **END** of `quickstart.rst` and `installation.rst` pointing to `:doc:\`support\`` (sparse — nowhere else)

### LeadGen attribution
Every "Hire us" link is **UTM-tagged** → `https://sosw.app` (contact form → `api.sosw.app/www/apply`):
`utm_source=github`, `utm_medium=readme` (README) / `utm_medium=docs` (docs), `utm_campaign=sosw-oss`.
(`utm_medium` added on top of the HQ-870 copy to let LeadGen split README vs docs referrals; source/campaign unchanged.)

### Verification
- `sphinx-build -b html` completes **exit 0**; `support.html` renders; footer + UTM CTAs render on content pages.
- The only build warnings are **pre-existing** `SyntaxWarning`s in `sosw/scheduler.py` (`\w` escape), unrelated to this change. My rst adds **zero** warnings.

### ⚠️ Decisions for Nik (this is why the PR is human-gated — `sosw/sosw` is NOT on any autonomous-merge list)
1. **Master-now vs 3.0 rebuild** (HQ-870 open question): land this lightweight version on current master (v0.7.51) now for immediate SEO/referral value, **and** bake the fuller docs version into the staged **3.0.0** docs rebuild (`3_0_0`, furo announcement banner)? The HQ-870 recommendation was: yes to both.
2. **Base branch / PyPI republish**: this PR targets **`master`** as the ticket requested. Note that per the sosw release convention PRs normally go to the closest staging branch (`0_9_1`), and a merge to `master` auto-publishes to PyPI. If you'd rather not trigger a docs-only republish, retarget the base to **`0_9_1`** or fold it into **`3_0_0`** — happy to move it.

### Out of scope (separate, admin-only — HQ-870 §1b)
Repo About/description/Website/topics are GitHub settings changes, not a code PR.

---
Ticket: HQ-875 · Plan of record: HQ-870 · relates to LeadGen.
`claude:vasya:tick`
